### PR TITLE
sequelize를 활용하여 income, account 모델 생성 및 관계 설정

### DIFF
--- a/server/src/models/account.js
+++ b/server/src/models/account.js
@@ -1,0 +1,48 @@
+module.exports = (sequelize, DataTypes) => {
+  const account = sequelize.define(
+    'account',
+    {
+      id: {
+        type: DataTypes.INTEGER,
+        allowNull: false,
+        primaryKey: true,
+        autoIncrement: true,
+      },
+      name: {
+        type: DataTypes.STRING,
+        allowNull: false,
+      },
+      color: {
+        type: DataTypes.STRING,
+        allowNull: false,
+      },
+    },
+    {
+      tableName: 'account',
+      underscored: true,
+      paranoid: true,
+    },
+  );
+
+  account.associate = (models) => {
+    account.belongsTo(models.accountbook, {
+      foreignKey: {
+        name: 'accountbookId',
+        allowNull: false,
+      },
+    });
+    account.hasMany(models.income, {
+      foreignKey: {
+        name: 'accountId',
+        allowNull: false,
+      },
+    });
+    account.hasMany(models.expenditure, {
+      foreignKey: {
+        name: 'accountId',
+        allowNull: false,
+      },
+    });
+  };
+  return account;
+};

--- a/server/src/models/income.js
+++ b/server/src/models/income.js
@@ -1,0 +1,56 @@
+module.exports = (sequelize, DataTypes) => {
+  const income = sequelize.define(
+    'income',
+    {
+      id: {
+        type: DataTypes.INTEGER,
+        allowNull: false,
+        primaryKey: true,
+        autoIncrement: true,
+      },
+      amount: {
+        type: DataTypes.INTEGER,
+        allowNull: false,
+      },
+      content: {
+        type: DataTypes.STRING,
+        allowNull: true,
+      },
+      date: {
+        type: DataTypes.DATE,
+        allowNull: false,
+      },
+      memo: {
+        type: DataTypes.STRING,
+        allowNull: true,
+      },
+    },
+    {
+      tableName: 'income',
+      underscored: true,
+      paranoid: true,
+    },
+  );
+
+  income.associate = (models) => {
+    income.belongsTo(models.incomeCategory, {
+      foreignKey: {
+        name: 'incomeCategoryId',
+        allowNull: false,
+      },
+    });
+    income.belongsTo(models.accountbook, {
+      foreignKey: {
+        name: 'accountbookId',
+        allowNull: false,
+      },
+    });
+    income.belongsTo(models.account, {
+      foreignKey: {
+        name: 'accountId',
+        allowNull: false,
+      },
+    });
+  };
+  return income;
+};

--- a/server/src/models/income.js
+++ b/server/src/models/income.js
@@ -14,7 +14,7 @@ module.exports = (sequelize, DataTypes) => {
       },
       content: {
         type: DataTypes.STRING,
-        allowNull: true,
+        allowNull: false,
       },
       date: {
         type: DataTypes.DATE,


### PR DESCRIPTION
## 관련 이슈
#11 sequelize 기반 테이블 생성

## 구현/수정 내용
- sequelize로 account 모델을 생성
- accountbook, income, expenditure과의 관계 설정

- sequelize로 income 모델을 생성
- income_category, accountbook, account와의 관계 설정

@boostcamp-2020/accountbook_mentor