### PR TITLE
storiesbook에 타입 지정, 타입 오류로 인해서 발생하는 에러 수정

### DIFF
--- a/client/src/components/graph/Circle.tsx
+++ b/client/src/components/graph/Circle.tsx
@@ -1,21 +1,26 @@
 import React from 'react';
 import styled, { keyframes } from 'styled-components';
 
-interface CircleSVGProps {
+export interface CircleSVGProps {
   beforePercent: number;
   myPercent: number;
   color: string;
   viewBox: number
 }
 
-interface CircleProp extends CircleSVGProps {
-  color: string;
-  remainPercent: number;
-  CircleDiameter: number;
+export interface StyledCircleSVG {
+  cx:number;
+  cy:number;
+  r:number;
+  beforePercent:number;
+  myPercent:number;
+  remainPercent:number;
+  color:string;
+  CircleDiameter:number;
 }
 
 
-const CircleAnimation = (AnimationProps: CircleProp) => keyframes`
+const CircleAnimation = (AnimationProps: StyledCircleSVG) => keyframes`
 100%{
   stroke-dasharray:${(() => {
 
@@ -32,12 +37,18 @@ const CircleAnimation = (AnimationProps: CircleProp) => keyframes`
   }
 `;
 
-const Circle = styled.circle`
+
+
+const Circle = styled.circle.attrs<StyledCircleSVG>(props=>({
+  cx:props.cx,
+  cy:props.cy,
+  r:props.r
+}))<StyledCircleSVG>`
 fill: transparent;
-stroke: ${(props: CircleProp) => props.color};
+stroke: ${(props) => props.color};
 stroke-width: 15;
-stroke-dasharray: 0, 0, 0, ${(props: CircleProp) => props.CircleDiameter};
-animation: ${(props: CircleProp) => CircleAnimation(props)} 1s ease-in both;
+stroke-dasharray: 0, 0, 0, ${(props) => props.CircleDiameter};
+animation: ${(props) => CircleAnimation(props)} 1s ease-in both;
 `;
 
 const CircleSVG = (props: CircleSVGProps) => {
@@ -50,7 +61,7 @@ const CircleSVG = (props: CircleSVGProps) => {
   }
 
 
-  const getCircleArea = (): object => {
+  const getCircleArea = (): {beforePercent:number,myPercent:number,remainPercent:number} => {
     const remain = 100 - (props.beforePercent + props.myPercent);
     const beforePercent = getLengthByRatio(props.beforePercent);
     const myPercent = getLengthByRatio(props.myPercent);
@@ -71,8 +82,10 @@ const CircleSVG = (props: CircleSVGProps) => {
       r={radius}
       color={props.color}
       CircleDiameter={CircleDiameter}
-      {...Areas}
-    ></Circle>
+      beforePercent={Areas.beforePercent}
+      myPercent={Areas.myPercent}
+      remainPercent={Areas.remainPercent}
+    />
   )
 }
 

--- a/client/src/components/graph/PieGraph.stories.tsx
+++ b/client/src/components/graph/PieGraph.stories.tsx
@@ -1,35 +1,42 @@
 import React from 'react';
-import PieGraphSVG from './PieGraph';
+import PieGraphSVG,{PieGraphProps} from './PieGraph';
+
+interface StoriesDefault{
+  component:React.ReactNode;
+  title:string;
+}
 
 export default {
   component: PieGraphSVG,
   title: 'PieGraphSVG',
+} as StoriesDefault;
+
+export const PieGraphDefault = ()=>{
+  const pieProps:PieGraphProps = {
+    transactionData:[{ title: '상품', color: 'green', ratio: 20 },
+  { title: '토마토', color: 'tomato', ratio: 30 },
+  { title: '물', color: 'blue', ratio: 10 },
+  { title: '닷져블루', color: 'dodgerblue', ratio: 40 }]
+}
+  return(
+    <PieGraphSVG transactionData={pieProps.transactionData}/>
+  )
 }
 
-const Template = args => <PieGraphSVG {...args} />;
+export const SmallSVG = ()=>{
+  const pieProps:PieGraphProps = {
+    transactionData:[{ title: '상품', color: 'green', ratio: 20 },
+      { title: '토마토', color: 'tomato', ratio: 30 },
+      { title: '물', color: 'blue', ratio: 10 },
+      { title: '닷져블루', color: 'dodgerblue', ratio: 40 }]
+  }
 
-export const Default = Template.bind({});
-
-Default.args = {
-  transactionData:
-    [{ title: '상품', color: 'green', ratio: 20 },
-    { title: '토마토', color: 'tomato', ratio: 30 },
-    { title: '물', color: 'blue', ratio: 10 },
-    { title: '닷져블루', color: 'dodgerblue', ratio: 40 }]
-};
-
-const Small = args => <div style={{
-  width: "200px",
-  height: "200px",
-}}><PieGraphSVG {...args} /></div>;
-
-export const SmallSVG = Small.bind({});
-
-
-SmallSVG.args = {
-  transactionData:
-    [{ title: '상품', color: 'green', ratio: 20 },
-    { title: '토마토', color: 'tomato', ratio: 30 },
-    { title: '물', color: 'blue', ratio: 10 },
-    { title: '닷져블루', color: 'dodgerblue', ratio: 40 }]
-};
+  return(
+    <div style={{
+      width:"200px",
+      height:"200px",
+    }}>
+      <PieGraphSVG {...pieProps}/>
+    </div>
+  )
+}

--- a/client/src/components/graph/PieGraph.tsx
+++ b/client/src/components/graph/PieGraph.tsx
@@ -25,7 +25,7 @@ interface PieDrawInfo {
   ratio: number;
 }
 
-interface PieGraphProps {
+export interface PieGraphProps {
   transactionData: PieDrawInfo[];
 }
 


### PR DESCRIPTION
- CircleSVG.tsx 파일에서 발생하는 타입 오류를 명시적 타입을 주는 방법으로 수정해서 해결했습니다.
- storiesbook의 컴포넌트에 모두 타입을 지정해줬습니다.