### PR TITLE
Category 컴포넌트 생성

### DIFF
--- a/client/src/components/category/Category.stories.tsx
+++ b/client/src/components/category/Category.stories.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import Category from './Category';
+
+export default {
+  title: 'category/Category',
+  component: Category,
+};
+
+export const WhiteTextCategory = (): JSX.Element => {
+  return <Category text={'영화'} bgColor={'#000000'} />;
+};
+
+export const BlackTextCategory = (): JSX.Element => {
+  return <Category text={'쇼핑/뷰티'} bgColor={'#E0F8EC'} />;
+};
+
+export const LongTextCategory = (): JSX.Element => {
+  return <Category text={'네이버부스트캠프'} bgColor={'#E0F8EC'} />;
+};

--- a/client/src/components/category/Category.tsx
+++ b/client/src/components/category/Category.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import Styled from 'styled-components';
 import { getTextColor } from '../../utils/color';
 
-const Div = Styled.div<{ bgColor: string; textColor: string }>`
+const CategoryWrapper = Styled.div<{ bgColor: string; textColor: string }>`
   width: 115px;
   background-color: ${({ bgColor }) => bgColor};
   color: ${({ textColor }) => textColor};
@@ -24,9 +24,9 @@ interface CategoryProps {
 const Category = ({ text, bgColor }: CategoryProps): JSX.Element => {
   const textColor = getTextColor(bgColor);
   return (
-    <Div bgColor={bgColor} textColor={textColor}>
+    <CategoryWrapper bgColor={bgColor} textColor={textColor}>
       {text}
-    </Div>
+    </CategoryWrapper>
   );
 };
 

--- a/client/src/components/category/Category.tsx
+++ b/client/src/components/category/Category.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import Styled from 'styled-components';
+import { getTextColor } from '../../utils/color';
+
+const Div = Styled.div<{ bgColor: string; textColor: string }>`
+  width: 115px;
+  background-color: ${({ bgColor }) => bgColor};
+  color: ${({ textColor }) => textColor};
+  box-sizing: border-box;
+  text-align: center;
+  padding: 7px 10px 7px 10px;
+  border-radius: 360px;
+  font-weight: 500;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+`;
+
+interface CategoryProps {
+  text: string;
+  bgColor: string;
+}
+
+const Category = ({ text, bgColor }: CategoryProps): JSX.Element => {
+  const textColor = getTextColor(bgColor);
+  return (
+    <Div bgColor={bgColor} textColor={textColor}>
+      {text}
+    </Div>
+  );
+};
+
+export default Category;

--- a/client/src/utils/color.ts
+++ b/client/src/utils/color.ts
@@ -1,0 +1,10 @@
+// 배경색에 따라 텍스트 색상을 리턴하는 함수
+export const getTextColor = (background: string): string => {
+  background = background.replace('#', '');
+  const r = parseInt(background.substr(0, 2), 16);
+  const g = parseInt(background.substr(2, 2), 16);
+  const b = parseInt(background.substr(4, 2), 16);
+  const yiq = (r * 299 + g * 587 + b * 114) / 1000;
+
+  return yiq >= 128 ? 'black' : 'white';
+};


### PR DESCRIPTION
## 관련 이슈
[공통 컴포넌트] 카테고리 컴포넌트 #58

## 구현/수정 내용
- 배경색이 밝은지 어두운지 판단해서 검정색 또는 하얀색의 텍스트색상을 반환하는 유틸함수를 생성하였습니다.
- 카테고리 및 다른 여러곳에서 재사용될 수 있는 Category 컴포넌트를 생성하였습니다.
- Category 컴포넌트 스토리를 생성하였습니다.

@boostcamp-2020/accountbook_mentor 

## 텍스트가 하얀색일 때
![image](https://user-images.githubusercontent.com/26829633/100067137-3a5c9a80-2e79-11eb-9b77-44cf8dfa5cb3.png)

## 텍스트가 검정색일 때
![image](https://user-images.githubusercontent.com/26829633/100067162-447e9900-2e79-11eb-8de0-d7bb1c82093c.png)

## 텍스트가 길 때
![image](https://user-images.githubusercontent.com/26829633/100067183-4cd6d400-2e79-11eb-9cfe-939e8e2f7646.png)

