### PR TITLE
뒤로가기 버튼 컴포넌트

### DIFF
--- a/client/src/components/back-button/BackButton.stories.tsx
+++ b/client/src/components/back-button/BackButton.stories.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import BackButton from './BackButton';
+import OvenBackButton from './OvenBackButton';
+
+export default {
+  title: '뒤로가기 버튼',
+  component: BackButton,
+};
+
+export const BackButtonDefault: React.FC = () => {
+  return <BackButton />;
+};
+
+export const SmallBackButtonDefault: React.FC = () => {
+  return (
+    <div
+      style={{
+        width: '100px',
+        height: '100px',
+      }}
+    >
+      <BackButton />
+    </div>
+  );
+};
+
+export const OvenBackButtonDefault: React.FC = () => {
+  return <OvenBackButton />;
+};

--- a/client/src/components/back-button/BackButton.tsx
+++ b/client/src/components/back-button/BackButton.tsx
@@ -1,16 +1,19 @@
 import React from 'react';
 
-interface BackButton{
-  onClick?:()=>void;
+interface BackButton {
+  onClick?: () => void;
 }
 
-const BackButton:React.FC<BackButton> = ({onClick}:BackButton)=>{
+const BackButton: React.FC<BackButton> = ({ onClick }: BackButton) => {
   return (
-  <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="32" height="32" viewBox="0 0 32 32" fill="#000000" data-svg-content="true">
-    <g>
-      <path d="M 4.292,15.708l 6,6c 0.39,0.39, 1.024,0.39, 1.414,0c 0.39-0.39, 0.39-1.024,0-1.414L 7.414,16L 22,16 c 4,0, 6,3.692, 6,7c0,0.552, 0.448,1, 1,1s 1-0.448, 1-1C 30,18.588, 28,14, 22,14L 7.414,14 l 4.292-4.292 c 0.39-0.39, 0.39-1.024,0-1.414c-0.39-0.39-1.024-0.39-1.414,0l-6,6C 3.902,14.684, 3.902,15.316, 4.292,15.708z"></path>
-    </g>
-    </svg>)
-}
+    <svg x="0px" y="0px" viewBox="0 0 306 306" onClick={onClick}>
+      <g>
+        <g id="chevron-left">
+          <polygon points="247.35,35.7 211.65,0 58.65,153 211.65,306 247.35,270.3 130.05,153   " />
+        </g>
+      </g>
+    </svg>
+  );
+};
 
 export default BackButton;

--- a/client/src/components/back-button/BackButton.tsx
+++ b/client/src/components/back-button/BackButton.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+interface BackButton{
+  onClick?:()=>void;
+}
+
+const BackButton:React.FC<BackButton> = ({onClick}:BackButton)=>{
+  return (
+  <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="32" height="32" viewBox="0 0 32 32" fill="#000000" data-svg-content="true">
+    <g>
+      <path d="M 4.292,15.708l 6,6c 0.39,0.39, 1.024,0.39, 1.414,0c 0.39-0.39, 0.39-1.024,0-1.414L 7.414,16L 22,16 c 4,0, 6,3.692, 6,7c0,0.552, 0.448,1, 1,1s 1-0.448, 1-1C 30,18.588, 28,14, 22,14L 7.414,14 l 4.292-4.292 c 0.39-0.39, 0.39-1.024,0-1.414c-0.39-0.39-1.024-0.39-1.414,0l-6,6C 3.902,14.684, 3.902,15.316, 4.292,15.708z"></path>
+    </g>
+    </svg>)
+}
+
+export default BackButton;

--- a/client/src/components/back-button/OvenBackButton.tsx
+++ b/client/src/components/back-button/OvenBackButton.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+interface OvenBackButtonProps {
+  onClick?: () => void;
+}
+
+const OvenBackButton: React.FC<OvenBackButtonProps> = ({ onClick }: OvenBackButtonProps) => {
+  return (
+    <svg onClick={onClick} width="32" height="32" viewBox="0 0 32 32" fill="#000000" data-svg-content="true">
+      <g>
+        <path d="M 4.292,15.708l 6,6c 0.39,0.39, 1.024,0.39, 1.414,0c 0.39-0.39, 0.39-1.024,0-1.414L 7.414,16L 22,16 c 4,0, 6,3.692, 6,7c0,0.552, 0.448,1, 1,1s 1-0.448, 1-1C 30,18.588, 28,14, 22,14L 7.414,14 l 4.292-4.292 c 0.39-0.39, 0.39-1.024,0-1.414c-0.39-0.39-1.024-0.39-1.414,0l-6,6C 3.902,14.684, 3.902,15.316, 4.292,15.708z"></path>
+      </g>
+    </svg>
+  );
+};
+
+export default OvenBackButton;


### PR DESCRIPTION
## 관련이슈
[공통 컴포넌트] 뒤로가기 #94

## 구현 세부사항
 
- flatIcon에서 주운 < 버튼 SVG와
- OvenApp에서 저희 프로토타입에 쓰인 SVG 두 버전으로 우선 생성해두었어요

##
### SmallBackButton
![SmallBackButton](https://user-images.githubusercontent.com/49854357/100206121-4748bf00-2f49-11eb-9028-d0dd03c632d3.png)

### OvenAppButton
![OvenAppButton](https://user-images.githubusercontent.com/49854357/100206150-50d22700-2f49-11eb-991c-46345d267a15.png)



@boostcamp-2020/accountbook_mentor 