### PR TITLE
colorPicker 동작방식 수정

### DIFF
--- a/client/src/components/color-picker/ColorPicker.stories.tsx
+++ b/client/src/components/color-picker/ColorPicker.stories.tsx
@@ -7,6 +7,7 @@ export default {
 };
 
 export const DefaultColorPicker = (): JSX.Element => {
-  const [color, setColor] = useState('#ffff00');
-  return <ColorPicker color={color} setColor={setColor} />;
+  const [accountbook, setAccountbook] = useState({ id: 3, color: '#ffff00' });
+  const [inputColor, setInputColor] = useState({ hex: accountbook.color });
+  return <ColorPicker inputColor={inputColor} setInputColor={setInputColor} />;
 };

--- a/client/src/components/color-picker/ColorPicker.tsx
+++ b/client/src/components/color-picker/ColorPicker.tsx
@@ -1,8 +1,8 @@
-import React, { useState, useEffect } from 'react';
-import Styled from 'styled-components';
+import React from 'react';
+import styled from 'styled-components';
 import InputColor from 'react-input-color';
 
-const ColorPickerWrapper = Styled.div`
+const ColorPickerWrapper = styled.div`
   width: 26px;
   height: 26px;
   svg {
@@ -20,20 +20,14 @@ const ColorPickerWrapper = Styled.div`
   }
 `;
 interface ColorPickerProps {
-  color: string;
-  setColor: (color: string) => void;
+  inputColor: { hex: string };
+  setInputColor: (color: { hex: string }) => void;
 }
 
-const ColorPicker = ({ color, setColor }: ColorPickerProps): JSX.Element => {
-  const [inputColor, setInputColor] = useState({ hex: color });
-
-  useEffect(() => {
-    setColor(inputColor.hex);
-  }, [inputColor]);
-
+const ColorPicker = ({ inputColor, setInputColor }: ColorPickerProps): JSX.Element => {
   return (
-    <ColorPickerWrapper color={color}>
-      <InputColor initialValue={color} onChange={setInputColor} placement="down" />
+    <ColorPickerWrapper color={inputColor.hex}>
+      <InputColor initialValue={inputColor.hex} onChange={setInputColor} placement="down" />
       <svg version="1.1" x="0px" y="0px" viewBox="0 0 1000 1000" enableBackground="new 0 0 1000 1000">
         <path d="M10,827.3h980V990H10V827.3z M785.2,478.9c54.9,60,82.3,107.8,82.3,143.6c0,21.7-8.3,40.8-24.9,57.4c-16.6,16.6-35.7,24.9-57.4,24.9s-40.5-8.3-56.5-24.9c-16-16.6-23.9-35.7-23.9-57.4c0-15.3,6.7-35.1,20.1-59.3c13.4-24.2,26.5-44,39.2-59.3L785.2,478.9z M222.5,417.7h392.4L417.7,222.5L222.5,417.7z M685.7,375.6c12.8,12.8,19.2,27.4,19.2,44s-6.4,30.6-19.2,42.1L461.7,685.6c-12.8,12.8-27.4,19.2-44,19.2c-15.3,0-29.4-6.4-42.1-19.2L149.8,461.7c-12.8-11.5-19.2-25.5-19.2-42.1s6.4-31.3,19.2-44L360.3,165l-97.6-97.6L322,10L685.7,375.6z" />
       </svg>


### PR DESCRIPTION
## 관련 이슈
[공통 컴포넌트] color picker 페인트통&팔레트 컴포넌트 #72 

## 구현/수정 내용

- 영근님의 리뷰를 반영하여 렌더링이 한번만 일어나도록 수정하였습니다.
>
>와 새벽에 진짜 수고 많으셨습니다~~~
>다름이 아니라 이 부분이 조금 걸려요. props-> state값을 매핑했잖아요? 만약 InputColor 값이 변경되면 onChange 이벤트에 의해서
>setInptuColor state가 변한뒤 (1) ColorPicker 컴포넌트 렌더링, 이 수행될것 같아요. 리 렌더링후 useEffect에 의해서 부모의 color가 변경되면 (2) 부모 컴포넌트 리렌더링 이 될것 같아요. color props 값이 변경되기 때문에 (3) ColorPicker 컴포넌트가 리 렌더링이 될것 같아요. state를 부모에게 전부 위임하고view만 보여주는 stateless 컴포넌트로 바꾸거나 아니면 색 정보를 자신의 state로 관리하는 컴포넌트가 되야할것 같아요.
>
>P.S props를 state에 다시 매핑하는것은 안티패턴이라고 해요
>https://www.reddit.com/r/javascript/comments/5t73cd/why_is_props_to_state_an_antipattern_in_reactjs/

@boostcamp-2020/accountbook_mentor 