### PR TITLE
sidebar가 storybook에서 출력되지 않는 문제 해결

### DIFF
--- a/client/src/components/home-button/HomeButton.stories.tsx
+++ b/client/src/components/home-button/HomeButton.stories.tsx
@@ -7,7 +7,7 @@ export default {
 };
 
 export const HomeButtonDefault: React.FC = () => {
-  return <HomeButton />;
+  return <HomeButton show={true} />;
 };
 
 export const SidebarHomeButton: React.FC = () => {
@@ -18,7 +18,7 @@ export const SidebarHomeButton: React.FC = () => {
         height: '100px',
       }}
     >
-      <HomeButton />
+      <HomeButton show={true} />
     </div>
   );
 };

--- a/client/src/components/plus-button/PlusButton.stories.tsx
+++ b/client/src/components/plus-button/PlusButton.stories.tsx
@@ -7,7 +7,7 @@ export default {
 };
 
 export const PlusButtonDefault: React.FC = () => {
-  return <PlusButton />;
+  return <PlusButton show={true} />;
 };
 
 export const SidebarPlusButton: React.FC = () => {
@@ -18,7 +18,7 @@ export const SidebarPlusButton: React.FC = () => {
         height: '50px',
       }}
     >
-      <PlusButton />
+      <PlusButton show={true} />
     </div>
   );
 };

--- a/client/src/components/small-accountbook-item/SmallAccountbookItem.stories.tsx
+++ b/client/src/components/small-accountbook-item/SmallAccountbookItem.stories.tsx
@@ -7,13 +7,13 @@ export default {
 };
 
 export const FirstSmallAccountbookItem = (): JSX.Element => {
-  return <SmallAccountbookItem id={1} bgColor={'#3498DB'} />;
+  return <SmallAccountbookItem id={1} show={true} bgColor={'#3498DB'} />;
 };
 
 export const SecondSmallAccountbookItem = (): JSX.Element => {
-  return <SmallAccountbookItem id={2} bgColor={'#2ecc70'} />;
+  return <SmallAccountbookItem id={2} show={true} bgColor={'#2ecc70'} />;
 };
 
 export const ThirdSmallAccountbookItem = (): JSX.Element => {
-  return <SmallAccountbookItem id={3} bgColor={'#f1c40f'} />;
+  return <SmallAccountbookItem id={3} show={true} bgColor={'#f1c40f'} />;
 };

--- a/client/src/components/small-accountbook-item/SmallAccountbookItem.tsx
+++ b/client/src/components/small-accountbook-item/SmallAccountbookItem.tsx
@@ -9,7 +9,7 @@ interface SmallAccountbookItemWrapperProps {
   onClick?: () => void;
 }
 
-const SmallAccountbookItemWrapper = Styled.div<SmallAccountbookItemWrapperProps>`
+const SmallAccountbookItemWrapper = styled.div<SmallAccountbookItemWrapperProps>`
   width: ${({ show }) => (show ? '40px' : '0')};
   height: ${({ show }) => (show ? '40px' : '0')};
   background-color: ${({ bgColor }) => bgColor};


### PR DESCRIPTION
## 관련 이슈
[가계부 내역 페이지] 사이드바 홈 버튼 오류 fix #54
[가계부 내역 페이지] 사이드바 가계부 버튼 오류 fix #55
[가계부 내역 페이지] 사이드바 가계부 생성 버튼 오류 fix #56

<br>

## 구현 세부사항
- #54 
   - HomeButton 스토리 파일에서 필요한 'show' props가 없어서 생기는 문제 해결

- #55 
   - SmallAccountbookItem 스토리 파일에서 필요한 'show' props가 없어서 생기는 문제 해결
   - Styled => styled 로 변경

- #56 
   - PlusButton 스토리 파일에서 필요한 'show' props가 없어서 생기는 문제 해결


<br>

@boostcamp-2020/accountbook_mentor 