### PR TITLE
modal 컴포넌트에 사용되는 form View 구현

### DIFF
--- a/client/src/__dummy-data__/components/modal/modalFilter.ts
+++ b/client/src/__dummy-data__/components/modal/modalFilter.ts
@@ -19,11 +19,12 @@ export const inputs = {
     items: dummyOptions,
   },
 };
+
 export const changes = {
   dateRage: (e: string): void => {
     console.log(e);
   },
-  payment: (e: string): void => {
+  payment: (e: string[]): void => {
     console.log(e);
   },
   incomeCategories: (e: string[]): void => {

--- a/client/src/__dummy-data__/components/modal/modalFilter.ts
+++ b/client/src/__dummy-data__/components/modal/modalFilter.ts
@@ -1,0 +1,35 @@
+import dummyOptions from '../inputs/dummyOptions';
+export const inputs = {
+  dateRange: {
+    placeholder: '기간',
+    items: dummyOptions,
+  },
+  startDate: '2020년 11월 12일',
+  endDate: '2020년 11월 18일',
+  payment: {
+    placeholder: '결제수단',
+    items: dummyOptions,
+  },
+  incomeCategories: {
+    placeholder: '수입',
+    items: dummyOptions,
+  },
+  expenditureCategories: {
+    placeholder: '지출',
+    items: dummyOptions,
+  },
+};
+export const changes = {
+  dateRage: (e: string): void => {
+    console.log(e);
+  },
+  payment: (e: string): void => {
+    console.log(e);
+  },
+  incomeCategories: (e: string[]): void => {
+    console.log(e);
+  },
+  expenditureCategories: (e: string[]): void => {
+    console.log(e);
+  },
+};

--- a/client/src/__dummy-data__/components/modal/modalTransactions.ts
+++ b/client/src/__dummy-data__/components/modal/modalTransactions.ts
@@ -1,0 +1,39 @@
+import dummyOptions from '../inputs/dummyOptions';
+export const inputs = {
+  price: 1000,
+  classify: true,
+  categories: {
+    placeholder: '카테고리',
+    items: dummyOptions,
+  },
+  accounts: {
+    placeholder: '결제수단',
+    items: dummyOptions,
+  },
+  date: '',
+};
+
+export const changes = {
+  price: (e: React.ChangeEvent<HTMLInputElement>): void => {
+    console.log(e.target.value);
+  },
+  classify: {
+    income: (): void => {
+      //
+    },
+    expenditure: (): void => {
+      //
+    },
+  },
+  categories: (change: string): void => {
+    console.log(change);
+    //
+  },
+  accounts: (change: string): void => {
+    console.log(change);
+  },
+  date: (e: React.ChangeEvent<HTMLInputElement>): void => {
+    console.log(e.target.value);
+    //
+  },
+};

--- a/client/src/components/common/inputs/Inputs.stories.tsx
+++ b/client/src/components/common/inputs/Inputs.stories.tsx
@@ -7,6 +7,7 @@ import SingleInputDropDown from './single-input-dropdown/SingleInputDropdown';
 import SelectPaymentMethod from './select-payment-method/SelectPaymentMethod';
 import MultiInputDropdownWithCheckBox from './multi-input-dropdown/MultiInputDropdownWithCheckBox';
 import ModalClassify from './modal-classify/ModalClassify';
+import InputDateTime from './input-datetime/InputDateTime';
 
 const SmallDiv = styled.div`
   width: 300px;
@@ -66,6 +67,14 @@ export const ModalIncome: React.FC = () => {
   return (
     <SmallDiv>
       <ModalClassify classify={false} onChange={onChange} value={'지출'} />
+    </SmallDiv>
+  );
+};
+
+export const InputDateTimeDefault: React.FC = () => {
+  return (
+    <SmallDiv>
+      <InputDateTime />
     </SmallDiv>
   );
 };

--- a/client/src/components/common/inputs/Inputs.stories.tsx
+++ b/client/src/components/common/inputs/Inputs.stories.tsx
@@ -60,7 +60,7 @@ export const SelectPaymentMethodDefault: React.FC = () => {
 };
 
 export const ModalIncome: React.FC = () => {
-  const onChange = (e: boolean) => {
+  const onChange = () => {
     //
   };
   return (

--- a/client/src/components/common/inputs/Inputs.stories.tsx
+++ b/client/src/components/common/inputs/Inputs.stories.tsx
@@ -6,6 +6,8 @@ import MultiInputDropDown from './multi-input-dropdown/MultiInputDropdown';
 import SingleInputDropDown from './single-input-dropdown/SingleInputDropdown';
 import SelectPaymentMethod from './select-payment-method/SelectPaymentMethod';
 import MultiInputDropdownWithCheckBox from './multi-input-dropdown/MultiInputDropdownWithCheckBox';
+import ModalClassify from './modal-classify/ModalClassify';
+
 const SmallDiv = styled.div`
   width: 300px;
 `;
@@ -53,6 +55,17 @@ export const SelectPaymentMethodDefault: React.FC = () => {
   return (
     <SmallDiv>
       <SelectPaymentMethod placeholder={'지출'} items={dummyOptions} />
+    </SmallDiv>
+  );
+};
+
+export const ModalIncome: React.FC = () => {
+  const onChange = (e: boolean) => {
+    //
+  };
+  return (
+    <SmallDiv>
+      <ModalClassify classify={false} onChange={onChange} value={'지출'} />
     </SmallDiv>
   );
 };

--- a/client/src/components/common/inputs/input-datetime/InputDateTime.tsx
+++ b/client/src/components/common/inputs/input-datetime/InputDateTime.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import styled from 'styled-components';
+
+const InputDateTimeWrapper = styled.input.attrs({
+  type: 'datetime-local',
+})`
+  width: 100%;
+  padding: 5px 10px;
+  font-size: 1.2rem;
+  border-radius: 5px;
+  border: 1px solid lightgray;
+`;
+
+interface InputDateTimeProps {
+  placeholder?: string;
+  value?: string;
+  onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
+}
+
+const InputDateTime: React.FC<InputDateTimeProps> = ({ value, onChange }: InputDateTimeProps) => {
+  return <InputDateTimeWrapper value={value} onChange={onChange} />;
+};
+
+export default InputDateTime;

--- a/client/src/components/common/inputs/input-text/InputText.tsx
+++ b/client/src/components/common/inputs/input-text/InputText.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import styled from 'styled-components';
 
 interface InputType {
-  type: string;
+  type: string | number;
 }
 
 const InputTextContainer = styled.input.attrs<InputType>({
@@ -17,8 +17,8 @@ const InputTextContainer = styled.input.attrs<InputType>({
 
 interface InputTextProps {
   placeholder: string;
-  value: string;
-  onChange: () => void;
+  value: string | number;
+  onChange: (e: string | number) => void;
 }
 
 const InputText: React.FC<InputTextProps> = ({ placeholder, value, onChange }: InputTextProps) => {

--- a/client/src/components/common/inputs/input-text/InputText.tsx
+++ b/client/src/components/common/inputs/input-text/InputText.tsx
@@ -16,9 +16,9 @@ const InputTextContainer = styled.input.attrs<InputType>({
 `;
 
 interface InputTextProps {
-  placeholder: string;
-  value: string | number;
-  onChange: (e: string | number) => void;
+  placeholder?: string;
+  value?: string | number;
+  onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
 }
 
 const InputText: React.FC<InputTextProps> = ({ placeholder, value, onChange }: InputTextProps) => {

--- a/client/src/components/common/inputs/modal-classify/ModalClassify.tsx
+++ b/client/src/components/common/inputs/modal-classify/ModalClassify.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 
 interface ModalClassify {
   value: string;
-  onChange: (target: boolean) => void;
+  onChange?: () => void;
   classify: boolean;
 }
 
@@ -22,7 +22,7 @@ const ModalClassifyWrapper = styled.div<WrapperProps>`
 
 const ModalClassify: React.FC<ModalClassify> = ({ value, onChange, classify }: ModalClassify) => {
   return (
-    <ModalClassifyWrapper classify={classify} onChange={onChange}>
+    <ModalClassifyWrapper classify={classify} onClick={onChange}>
       {value}
     </ModalClassifyWrapper>
   );

--- a/client/src/components/common/inputs/modal-classify/ModalClassify.tsx
+++ b/client/src/components/common/inputs/modal-classify/ModalClassify.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import styled from 'styled-components';
+
+interface ModalClassify {
+  value: string;
+  onChange: (target: boolean) => void;
+  classify: boolean;
+}
+
+interface WrapperProps {
+  classify: boolean;
+}
+const ModalClassifyWrapper = styled.div<WrapperProps>`
+  border-radius: 30px;
+  padding: 5px 20px;
+  margin: 0px;
+  text-align: center;
+  background-color: ${(props) => (props.classify ? '#ffffff' : '#52ACE8')};
+  color: ${(props) => (props.classify ? 'black' : 'white')};
+`;
+
+const ModalClassify: React.FC<ModalClassify> = ({ value, onChange, classify }: ModalClassify) => {
+  return (
+    <ModalClassifyWrapper classify={classify} onChange={onChange}>
+      {value}
+    </ModalClassifyWrapper>
+  );
+};
+
+export default ModalClassify;

--- a/client/src/components/common/inputs/modal-classify/ModalClassify.tsx
+++ b/client/src/components/common/inputs/modal-classify/ModalClassify.tsx
@@ -15,6 +15,7 @@ const ModalClassifyWrapper = styled.div<WrapperProps>`
   padding: 5px 20px;
   margin: 0px;
   text-align: center;
+  cursor: pointer;
   background-color: ${(props) => (props.classify ? '#ffffff' : '#52ACE8')};
   color: ${(props) => (props.classify ? 'black' : 'white')};
 `;

--- a/client/src/components/common/inputs/modal-classify/ModalClassify.tsx
+++ b/client/src/components/common/inputs/modal-classify/ModalClassify.tsx
@@ -16,8 +16,8 @@ const ModalClassifyWrapper = styled.div<WrapperProps>`
   margin: 0px;
   text-align: center;
   cursor: pointer;
-  background-color: ${(props) => (props.classify ? '#ffffff' : '#52ACE8')};
-  color: ${(props) => (props.classify ? 'black' : 'white')};
+  background-color: ${(props) => (props.classify ? '#52ACE8' : '#ffffff')};
+  color: ${(props) => (props.classify ? 'white' : 'black')};
 `;
 
 const ModalClassify: React.FC<ModalClassify> = ({ value, onChange, classify }: ModalClassify) => {

--- a/client/src/components/common/inputs/multi-input-dropdown/MultiInputDropdownWithCheckBox.tsx
+++ b/client/src/components/common/inputs/multi-input-dropdown/MultiInputDropdownWithCheckBox.tsx
@@ -66,7 +66,7 @@ const MultiInputDropdownWithCheckBox: React.FC<Props> = ({ placeholder, items, c
   return (
     <ComponentWrapper>
       <CheckBoxArea>
-        <CheckBox type="checkbox" checked={checkBoxClicked} onClick={checkBoxToggle} />
+        <CheckBox type="checkbox" checked={checkBoxClicked} onChange={checkBoxToggle} />
         <Label onClick={checkBoxToggle}>{checkBoxName}</Label>
       </CheckBoxArea>
       <DropdownWrapper>

--- a/client/src/components/common/inputs/select/Select.tsx
+++ b/client/src/components/common/inputs/select/Select.tsx
@@ -29,6 +29,7 @@ const SelectWrapper = styled.div<SelectWrapperProps>`
   border-radius: 5px;
   border: 1px solid lightgray;
   position: relative;
+  background-color: white;
 `;
 
 const SelectTitle = styled.p`

--- a/client/src/components/common/modals/accountbook-delete-by-admin/AccountbookDeleteByAdminModal.tsx
+++ b/client/src/components/common/modals/accountbook-delete-by-admin/AccountbookDeleteByAdminModal.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import styled from 'styled-components';
-import GrayButton from '../buttons/GrayButton';
-import RedButton from '../buttons/RedButton';
-import ModalBackground from '../modal-background/ModalBackground';
+import GrayButton from '../../buttons/GrayButton';
+import RedButton from '../../buttons/RedButton';
+import ModalBackground from '../../modal-background/ModalBackground';
 
 interface IProps {
   cancelClick?: () => void;

--- a/client/src/components/common/modals/form-modal-filter/FormFilter.tsx
+++ b/client/src/components/common/modals/form-modal-filter/FormFilter.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import styled from 'styled-components';
 import { Options } from '../../../../types/options';
 import SingleInputDropdown from '../../inputs/single-input-dropdown/SingleInputDropdown';
-import SelectPaymentMethod from '../../inputs/select-payment-method';
+import SelectPaymentMethod from '../../inputs/select-payment-method/SelectPaymentMethod';
 import MultiInputDropdownWithCheckBox from '../../inputs/multi-input-dropdown/MultiInputDropdownWithCheckBox';
 
 interface IFormModalFilter {
@@ -70,7 +70,7 @@ const FormModalFilter: React.FC<IFormModalFilter> = ({ inputs, changes }: IFormM
       </InputWrapper>
       <InputWrapper>
         <InputLabel>결제수단</InputLabel>
-        <SingleInputDropdown placeholder={'결제수단'} items={inputs.payment.items} onChange={changes.payment} />
+        <SelectPaymentMethod placeholder={'결제수단'} items={inputs.payment.items} onChange={changes.payment} />
       </InputWrapper>
       <InputWrapper>
         <InputLabel>카테고리</InputLabel>

--- a/client/src/components/common/modals/form-modal-filter/FormFilter.tsx
+++ b/client/src/components/common/modals/form-modal-filter/FormFilter.tsx
@@ -1,0 +1,94 @@
+import React from 'react';
+import styled from 'styled-components';
+import { Options } from '../../../../types/options';
+import SingleInputDropdown from '../../inputs/single-input-dropdown/SingleInputDropdown';
+import SelectPaymentMethod from '../../inputs/select-payment-method';
+import MultiInputDropdownWithCheckBox from '../../inputs/multi-input-dropdown/MultiInputDropdownWithCheckBox';
+
+interface IFormModalFilter {
+  inputs: {
+    dateRange: {
+      placeholder: string;
+      items: Options[];
+    };
+    startDate: string;
+    endDate: string;
+    payment: {
+      placeholder: string;
+      items: Options[];
+    };
+    incomeCategories: {
+      placeholder: string;
+      items: Options[];
+    };
+    expenditureCategories: {
+      placeholder: string;
+      items: Options[];
+    };
+  };
+  changes: {
+    dateRage: (e: string) => void;
+    payment: (e: string[]) => void;
+    incomeCategories: (e: string[]) => void;
+    expenditureCategories: (e: string[]) => void;
+  };
+}
+
+const FormModalWrapper = styled.div`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`;
+
+const InputWrapper = styled.div`
+  width: 70%;
+  padding: 0%;
+  margin: 0%;
+`;
+
+const InputLabel = styled.p`
+  font-size: 1.3em;
+`;
+
+const DateRange = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+`;
+
+const FormModalFilter: React.FC<IFormModalFilter> = ({ inputs, changes }: IFormModalFilter) => {
+  return (
+    <FormModalWrapper>
+      <InputWrapper>
+        <InputLabel>기간</InputLabel>
+        <SingleInputDropdown placeholder={'기간'} items={inputs.dateRange.items} onChange={changes?.dateRage} />
+        <DateRange>
+          <p>{inputs.startDate}</p>
+          <p>{inputs.endDate}</p>
+        </DateRange>
+      </InputWrapper>
+      <InputWrapper>
+        <InputLabel>결제수단</InputLabel>
+        <SingleInputDropdown placeholder={'결제수단'} items={inputs.payment.items} onChange={changes.payment} />
+      </InputWrapper>
+      <InputWrapper>
+        <InputLabel>카테고리</InputLabel>
+        <MultiInputDropdownWithCheckBox
+          placeholder={'지출'}
+          checkBoxName={'지출'}
+          items={inputs.expenditureCategories.items}
+          onChange={changes.expenditureCategories}
+        />
+        <MultiInputDropdownWithCheckBox
+          placeholder={'수입'}
+          checkBoxName={'수입'}
+          items={inputs.incomeCategories.items}
+          onChange={changes.expenditureCategories}
+        />
+      </InputWrapper>
+    </FormModalWrapper>
+  );
+};
+
+export default FormModalFilter;

--- a/client/src/components/common/modals/form-modal-header/FormModalHeader.tsx
+++ b/client/src/components/common/modals/form-modal-header/FormModalHeader.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import styled from 'styled-components';
+import ModalBackButton from '../../back-button/ModalBackButton';
+
+interface IFormModalHeaderProps {
+  closeModal?: () => void;
+  clickMMS?: () => void;
+  clickRed?: () => void;
+  clickBlue?: () => void;
+  modalName?: string;
+  blueName?: string;
+  redName?: string;
+  mms?: boolean;
+}
+
+const Header = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+`;
+
+const CloseModalButtonWrapper = styled.div`
+  cursor: pointer;
+  width: 1.3em;
+  margin-right: 1em;
+`;
+
+const Right = styled.p`
+  margin-left: auto;
+`;
+
+const ModalName = styled.p`
+  cursor: pointer;
+  font-size: 1.3em;
+`;
+
+const RedButton = styled.p`
+  cursor: pointer;
+  color:tomato;
+  margin-right: 1em;
+`;
+
+const BlueButton = styled.p`
+  cursor: pointer;
+  color:dodgerblue;
+`;
+
+const FormModalHeader: React.FC<IFormModalHeaderProps> = ({
+  closeModal,
+  clickMMS,
+  clickRed,
+  clickBlue,
+  modalName,
+  blueName,
+  redName,
+  mms,
+}: IFormModalHeaderProps) => {
+  return (
+    <Header>
+      <CloseModalButtonWrapper>
+        <ModalBackButton onClick={closeModal} />
+      </CloseModalButtonWrapper>
+      <ModalName>{modalName}</ModalName>
+      <Right />
+      {mms}
+      {redName && <RedButton onClick={clickRed}>{redName}</RedButton>}
+      {blueName && <BlueButton onClick={clickBlue}>{blueName}</BlueButton>}
+    </Header>
+  );
+};
+
+export default FormModalHeader;

--- a/client/src/components/common/modals/form-modal-header/FormModalHeader.tsx
+++ b/client/src/components/common/modals/form-modal-header/FormModalHeader.tsx
@@ -36,13 +36,13 @@ const ModalName = styled.p`
 
 const RedButton = styled.p`
   cursor: pointer;
-  color:tomato;
+  color: tomato;
   margin-right: 1em;
 `;
 
 const BlueButton = styled.p`
   cursor: pointer;
-  color:dodgerblue;
+  color: dodgerblue;
 `;
 
 const FormModalHeader: React.FC<IFormModalHeaderProps> = ({

--- a/client/src/components/common/modals/form-modal-template/FormModalWrapper.tsx
+++ b/client/src/components/common/modals/form-modal-template/FormModalWrapper.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { MODAL_WHITE } from '../../../../constants/color';
+import styled from 'styled-components';
+
+interface IFormModal {
+  children: React.ReactNode;
+}
+
+const FormModalWrapper = styled.div`
+  background-color: ${MODAL_WHITE};
+  width: 80%;
+  padding: 20px;
+`;
+
+const FormModal: React.FC<IFormModal> = ({ children }: IFormModal) => {
+  return <FormModalWrapper>{children}</FormModalWrapper>;
+};
+
+export default FormModal;

--- a/client/src/components/common/modals/form-modal-transaction/TransactionInputList.tsx
+++ b/client/src/components/common/modals/form-modal-transaction/TransactionInputList.tsx
@@ -32,7 +32,7 @@ interface ITransactionInputList {
     accounts: (change: string) => void;
     content?: (e: React.ChangeEvent<HTMLInputElement>) => void;
     date?: (e: React.ChangeEvent<HTMLInputElement>) => void;
-    memo?: (change: string) => void;
+    memo?: (e: React.ChangeEvent<HTMLInputElement>) => void;
   };
 }
 

--- a/client/src/components/common/modals/form-modal-transaction/TransactionInputList.tsx
+++ b/client/src/components/common/modals/form-modal-transaction/TransactionInputList.tsx
@@ -108,9 +108,22 @@ const TransactionInputList: React.FC<ITransactionInputList> = ({ inputs, changes
         </Inputs>
       </InputWrapper>
       <InputWrapper>
-        <InputLabel>거래처</InputLabel>
+        <InputLabel>내용</InputLabel>
+        <Inputs>
+          <InputText placeholder={'날짜'} value={inputs.content} onChange={changes.content} />
+        </Inputs>
+      </InputWrapper>
+      <InputWrapper>
+        <InputLabel>날짜</InputLabel>
         <Inputs>
           <InputDateTime value={inputs.date} onChange={changes.date} />
+        </Inputs>
+      </InputWrapper>
+
+      <InputWrapper>
+        <InputLabel>메모</InputLabel>
+        <Inputs>
+          <InputText placeholder={'메모'} value={inputs.memo} onChange={changes.memo} />
         </Inputs>
       </InputWrapper>
     </InputListWrapper>

--- a/client/src/components/common/modals/form-modal-transaction/TransactionInputList.tsx
+++ b/client/src/components/common/modals/form-modal-transaction/TransactionInputList.tsx
@@ -3,17 +3,18 @@ import styled from 'styled-components';
 import { Options } from '../../../../types/options';
 import InputText from '../../inputs/input-text/InputText';
 import ModalClassify from '../../inputs/modal-classify/ModalClassify';
+import SingleInputDropdown from '../../inputs/single-input-dropdown/SingleInputDropdown';
 interface ITransactionInputList {
   inputs: {
     classify: boolean;
     price?: number;
-    categories?: {
+    categories: {
       placeholder: string;
-      items: Options;
+      items: Options[];
     };
     accounts?: {
       placeholder: string;
-      items: Options;
+      items: Options[];
     };
     content?: string;
     date?: string;
@@ -26,7 +27,7 @@ interface ITransactionInputList {
       expenditure: () => void;
     };
     price?: (e: React.ChangeEvent<HTMLInputElement>) => void;
-    categories?: (change: string) => void;
+    categories: (change: string) => void;
     accounts?: (change: string) => void;
     content?: (e: React.ChangeEvent<HTMLInputElement>) => void;
     date?: (e: React.ChangeEvent<HTMLInputElement>) => void;
@@ -87,6 +88,12 @@ const TransactionInputList: React.FC<ITransactionInputList> = ({ inputs, changes
         <InputLabel>금액</InputLabel>
         <Inputs>
           <InputText placeholder={'금액'} value={inputs.price} onChange={changes.price} />
+        </Inputs>
+      </InputWrapper>
+      <InputWrapper>
+        <InputLabel>카테고리</InputLabel>
+        <Inputs>
+          <SingleInputDropdown placeholder={'카테고리'} items={inputs.categories.items} onChange={changes.categories} />
         </Inputs>
       </InputWrapper>
     </InputListWrapper>

--- a/client/src/components/common/modals/form-modal-transaction/TransactionInputList.tsx
+++ b/client/src/components/common/modals/form-modal-transaction/TransactionInputList.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import styled from 'styled-components';
+
+const InputListWrapper = styled.div`
+  width: 100%;
+  display: flex;
+  align-items: center;
+`;
+
+const TransactionInputList: React.FC = () => {
+  return <InputListWrapper>zz</InputListWrapper>;
+};
+
+export default TransactionInputList;

--- a/client/src/components/common/modals/form-modal-transaction/TransactionInputList.tsx
+++ b/client/src/components/common/modals/form-modal-transaction/TransactionInputList.tsx
@@ -53,7 +53,7 @@ const InputWrapper = styled.div`
 `;
 
 const InputLabel = styled.div`
-  width: 30%;
+  width: 20%;
   padding: 0%;
   margin: 0%;
 `;

--- a/client/src/components/common/modals/form-modal-transaction/TransactionInputList.tsx
+++ b/client/src/components/common/modals/form-modal-transaction/TransactionInputList.tsx
@@ -4,6 +4,7 @@ import { Options } from '../../../../types/options';
 import InputText from '../../inputs/input-text/InputText';
 import ModalClassify from '../../inputs/modal-classify/ModalClassify';
 import SingleInputDropdown from '../../inputs/single-input-dropdown/SingleInputDropdown';
+import InputDateTime from '../../inputs/input-datetime/InputDateTime';
 interface ITransactionInputList {
   inputs: {
     classify: boolean;
@@ -108,7 +109,9 @@ const TransactionInputList: React.FC<ITransactionInputList> = ({ inputs, changes
       </InputWrapper>
       <InputWrapper>
         <InputLabel>거래처</InputLabel>
-        <Inputs></Inputs>
+        <Inputs>
+          <InputDateTime value={inputs.date} onChange={changes.date} />
+        </Inputs>
       </InputWrapper>
     </InputListWrapper>
   );

--- a/client/src/components/common/modals/form-modal-transaction/TransactionInputList.tsx
+++ b/client/src/components/common/modals/form-modal-transaction/TransactionInputList.tsx
@@ -2,10 +2,10 @@ import React from 'react';
 import styled from 'styled-components';
 import { Options } from '../../../../types/options';
 import InputText from '../../inputs/input-text/InputText';
-
+import ModalClassify from '../../inputs/modal-classify/ModalClassify';
 interface ITransactionInputList {
   inputs: {
-    classify?: boolean;
+    classify: boolean;
     price?: number;
     categories?: {
       placeholder: string;
@@ -21,12 +21,15 @@ interface ITransactionInputList {
   };
 
   changes: {
-    classify?: (change: boolean) => void;
+    classify?: {
+      income: () => void;
+      expenditure: () => void;
+    };
     price?: (e: React.ChangeEvent<HTMLInputElement>) => void;
     categories?: (change: string) => void;
     accounts?: (change: string) => void;
-    content?: (change: string) => void;
-    date?: (change: string) => void;
+    content?: (e: React.ChangeEvent<HTMLInputElement>) => void;
+    date?: (e: React.ChangeEvent<HTMLInputElement>) => void;
     memo?: (change: string) => void;
   };
 }
@@ -44,6 +47,7 @@ const InputWrapper = styled.div`
   margin: 0%;
   display: flex;
   align-items: center;
+  margin-top: 10px;
 `;
 
 const InputLabel = styled.div`
@@ -56,11 +60,29 @@ const Inputs = styled.div`
   flex: 1;
   padding: 0%;
   margin: 0%;
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+`;
+
+const ClassifyWrapper = styled.div`
+  width: 45%;
 `;
 
 const TransactionInputList: React.FC<ITransactionInputList> = ({ inputs, changes }: ITransactionInputList) => {
   return (
     <InputListWrapper>
+      <InputWrapper>
+        <InputLabel>분류</InputLabel>
+        <Inputs>
+          <ClassifyWrapper>
+            <ModalClassify value={'수입'} classify={inputs.classify} onChange={changes.classify?.income} />
+          </ClassifyWrapper>
+          <ClassifyWrapper>
+            <ModalClassify value={'지출'} classify={!inputs.classify} onChange={changes.classify?.expenditure} />
+          </ClassifyWrapper>
+        </Inputs>
+      </InputWrapper>
       <InputWrapper>
         <InputLabel>금액</InputLabel>
         <Inputs>

--- a/client/src/components/common/modals/form-modal-transaction/TransactionInputList.tsx
+++ b/client/src/components/common/modals/form-modal-transaction/TransactionInputList.tsx
@@ -1,14 +1,74 @@
 import React from 'react';
 import styled from 'styled-components';
+import { Options } from '../../../../types/options';
+import InputText from '../../inputs/input-text/InputText';
+
+interface ITransactionInputList {
+  inputs: {
+    classify?: boolean;
+    price?: number;
+    categories?: {
+      placeholder: string;
+      items: Options;
+    };
+    accounts?: {
+      placeholder: string;
+      items: Options;
+    };
+    content?: string;
+    date?: string;
+    memo?: string;
+  };
+
+  changes: {
+    classify?: (change: boolean) => void;
+    price?: (change: number | string) => void;
+    categories?: (change: string) => void;
+    accounts?: (change: string) => void;
+    content?: (change: string) => void;
+    date?: (change: string) => void;
+    memo?: (change: string) => void;
+  };
+}
 
 const InputListWrapper = styled.div`
   width: 100%;
   display: flex;
+  flex-direction: column;
   align-items: center;
 `;
 
-const TransactionInputList: React.FC = () => {
-  return <InputListWrapper>zz</InputListWrapper>;
+const InputWrapper = styled.div`
+  width: 70%;
+  padding: 0%;
+  margin: 0%;
+  display: flex;
+  align-items: center;
+`;
+
+const InputLabel = styled.div`
+  width: 30%;
+  padding: 0%;
+  margin: 0%;
+`;
+
+const Inputs = styled.div`
+  flex: 1;
+  padding: 0%;
+  margin: 0%;
+`;
+
+const TransactionInputList: React.FC<ITransactionInputList> = ({ inputs, changes }: ITransactionInputList) => {
+  return (
+    <InputListWrapper>
+      <InputWrapper>
+        <InputLabel>금액</InputLabel>
+        <Inputs>
+          <InputText placeholder={'금액'} value={inputs.price} onChange={changes.price} />
+        </Inputs>
+      </InputWrapper>
+    </InputListWrapper>
+  );
 };
 
 export default TransactionInputList;

--- a/client/src/components/common/modals/form-modal-transaction/TransactionInputList.tsx
+++ b/client/src/components/common/modals/form-modal-transaction/TransactionInputList.tsx
@@ -22,7 +22,7 @@ interface ITransactionInputList {
 
   changes: {
     classify?: (change: boolean) => void;
-    price?: (change: number | string) => void;
+    price?: (e: React.ChangeEvent<HTMLInputElement>) => void;
     categories?: (change: string) => void;
     accounts?: (change: string) => void;
     content?: (change: string) => void;

--- a/client/src/components/common/modals/form-modal-transaction/TransactionInputList.tsx
+++ b/client/src/components/common/modals/form-modal-transaction/TransactionInputList.tsx
@@ -12,7 +12,7 @@ interface ITransactionInputList {
       placeholder: string;
       items: Options[];
     };
-    accounts?: {
+    accounts: {
       placeholder: string;
       items: Options[];
     };
@@ -28,7 +28,7 @@ interface ITransactionInputList {
     };
     price?: (e: React.ChangeEvent<HTMLInputElement>) => void;
     categories: (change: string) => void;
-    accounts?: (change: string) => void;
+    accounts: (change: string) => void;
     content?: (e: React.ChangeEvent<HTMLInputElement>) => void;
     date?: (e: React.ChangeEvent<HTMLInputElement>) => void;
     memo?: (change: string) => void;
@@ -95,6 +95,20 @@ const TransactionInputList: React.FC<ITransactionInputList> = ({ inputs, changes
         <Inputs>
           <SingleInputDropdown placeholder={'카테고리'} items={inputs.categories.items} onChange={changes.categories} />
         </Inputs>
+      </InputWrapper>
+      <InputWrapper>
+        <InputLabel>결제수단</InputLabel>
+        <Inputs>
+          <SingleInputDropdown
+            placeholder={'결제수단을 선택하세요'}
+            items={inputs.accounts?.items}
+            onChange={changes.accounts}
+          />
+        </Inputs>
+      </InputWrapper>
+      <InputWrapper>
+        <InputLabel>거래처</InputLabel>
+        <Inputs></Inputs>
       </InputWrapper>
     </InputListWrapper>
   );

--- a/client/src/components/common/modals/modals.stories.tsx
+++ b/client/src/components/common/modals/modals.stories.tsx
@@ -45,6 +45,7 @@ const inputs = {
     placeholder: '결제수단',
     items: dummyOptions,
   },
+  date: '',
 };
 
 const changes = {
@@ -65,6 +66,10 @@ const changes = {
   },
   accounts: (change: string) => {
     console.log(change);
+  },
+  date: (e: React.ChangeEvent<HTMLInputElement>): void => {
+    console.log(e.target.value);
+    //
   },
 };
 

--- a/client/src/components/common/modals/modals.stories.tsx
+++ b/client/src/components/common/modals/modals.stories.tsx
@@ -3,7 +3,9 @@ import dummyOptions from '../../../__dummy-data__/components/inputs/dummyOptions
 import AcoountbookDeleteByAdminModal from './accountbook-delete-by-admin/AccountbookDeleteByAdminModal';
 import FormModalHeader from './form-modal-header/FormModalHeader';
 import TransactionInputList from './form-modal-transaction/TransactionInputList';
+import FormFilter from './form-modal-filter/FormFilter';
 import { inputs, changes } from '../../../__dummy-data__/components/modal/modalTransactions';
+import { inputs as filterInputs, changes as filterChanges } from '../../../__dummy-data__/components/modal/modalFilter';
 export default {
   title: 'Modal Example',
 };
@@ -39,6 +41,14 @@ export const TransactionInputListDefault: React.FC = () => {
   return (
     <div style={{ backgroundColor: '#ECECEC' }}>
       <TransactionInputList inputs={inputs} changes={changes} />
+    </div>
+  );
+};
+
+export const FormFilterDefault: React.FC = () => {
+  return (
+    <div style={{ backgroundColor: '#ECECEC' }}>
+      <FormFilter inputs={filterInputs} changes={filterChanges} />
     </div>
   );
 };

--- a/client/src/components/common/modals/modals.stories.tsx
+++ b/client/src/components/common/modals/modals.stories.tsx
@@ -41,11 +41,15 @@ const inputs = {
     placeholder: '카테고리',
     items: dummyOptions,
   },
+  accounts: {
+    placeholder: '결제수단',
+    items: dummyOptions,
+  },
 };
 
 const changes = {
   price: (e: React.ChangeEvent<HTMLInputElement>): void => {
-    console.log(e);
+    console.log(e.target.value);
   },
   classify: {
     income: () => {
@@ -56,7 +60,11 @@ const changes = {
     },
   },
   categories: (change: string) => {
+    console.log(change);
     //
+  },
+  accounts: (change: string) => {
+    console.log(change);
   },
 };
 

--- a/client/src/components/common/modals/modals.stories.tsx
+++ b/client/src/components/common/modals/modals.stories.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import AcoountbookDeleteByAdminModal from './accountbook-delete-by-admin/AccountbookDeleteByAdminModal';
 import FormModalHeader from './form-modal-header/FormModalHeader';
+import TransactionInputList from './form-modal-transaction/TransactionInputList';
 export default {
   title: 'Modal Example',
 };
@@ -30,4 +31,18 @@ export const AccountbookDeleteByAdminDefault: React.FC = () => {
 
 export const FormModalHeaderDefault: React.FC = () => {
   return <FormModalHeader modalName={'내역 변경'} blueName={'완료'} redName={'삭제'} />;
+};
+
+const inputs = {
+  price: 1000,
+};
+
+const changes = {
+  price: (e: string): void => {
+    console.log(e);
+  },
+};
+
+export const TransactionInputListDefault: React.FC = () => {
+  return <TransactionInputList inputs={inputs} changes={changes} />;
 };

--- a/client/src/components/common/modals/modals.stories.tsx
+++ b/client/src/components/common/modals/modals.stories.tsx
@@ -35,14 +35,27 @@ export const FormModalHeaderDefault: React.FC = () => {
 
 const inputs = {
   price: 1000,
+  classify: true,
 };
 
 const changes = {
   price: (e: React.ChangeEvent<HTMLInputElement>): void => {
     console.log(e);
   },
+  classify: {
+    income: () => {
+      //
+    },
+    expenditure: () => {
+      //
+    },
+  },
 };
 
 export const TransactionInputListDefault: React.FC = () => {
-  return <TransactionInputList inputs={inputs} changes={changes} />;
+  return (
+    <div style={{ backgroundColor: 'gray' }}>
+      <TransactionInputList inputs={inputs} changes={changes} />;
+    </div>
+  );
 };

--- a/client/src/components/common/modals/modals.stories.tsx
+++ b/client/src/components/common/modals/modals.stories.tsx
@@ -3,6 +3,7 @@ import dummyOptions from '../../../__dummy-data__/components/inputs/dummyOptions
 import AcoountbookDeleteByAdminModal from './accountbook-delete-by-admin/AccountbookDeleteByAdminModal';
 import FormModalHeader from './form-modal-header/FormModalHeader';
 import TransactionInputList from './form-modal-transaction/TransactionInputList';
+import { inputs, changes } from '../../../__dummy-data__/components/modal/modalTransactions';
 export default {
   title: 'Modal Example',
 };
@@ -32,45 +33,6 @@ export const AccountbookDeleteByAdminDefault: React.FC = () => {
 
 export const FormModalHeaderDefault: React.FC = () => {
   return <FormModalHeader modalName={'내역 변경'} blueName={'완료'} redName={'삭제'} />;
-};
-
-const inputs = {
-  price: 1000,
-  classify: true,
-  categories: {
-    placeholder: '카테고리',
-    items: dummyOptions,
-  },
-  accounts: {
-    placeholder: '결제수단',
-    items: dummyOptions,
-  },
-  date: '',
-};
-
-const changes = {
-  price: (e: React.ChangeEvent<HTMLInputElement>): void => {
-    console.log(e.target.value);
-  },
-  classify: {
-    income: () => {
-      //
-    },
-    expenditure: () => {
-      //
-    },
-  },
-  categories: (change: string) => {
-    console.log(change);
-    //
-  },
-  accounts: (change: string) => {
-    console.log(change);
-  },
-  date: (e: React.ChangeEvent<HTMLInputElement>): void => {
-    console.log(e.target.value);
-    //
-  },
 };
 
 export const TransactionInputListDefault: React.FC = () => {

--- a/client/src/components/common/modals/modals.stories.tsx
+++ b/client/src/components/common/modals/modals.stories.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import AcoountbookDeleteByAdminModal from './accountbook-delete-by-admin/AccountbookDeleteByAdminModal';
-
+import FormModalHeader from './form-modal-header/FormModalHeader';
 export default {
   title: 'Modal Example',
 };
@@ -26,4 +26,8 @@ export const AccountbookDeleteByAdminDefault: React.FC = () => {
       closeModal={closeModal}
     />
   );
+};
+
+export const FormModalHeaderDefault: React.FC = () => {
+  return <FormModalHeader modalName={'내역 변경'} blueName={'완료'} redName={'삭제'} />;
 };

--- a/client/src/components/common/modals/modals.stories.tsx
+++ b/client/src/components/common/modals/modals.stories.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import AcoountbookDeleteByAdminModal from './AccountbookDeleteByAdminModal';
+import AcoountbookDeleteByAdminModal from './accountbook-delete-by-admin/AccountbookDeleteByAdminModal';
 
 export default {
   title: 'Modal Example',

--- a/client/src/components/common/modals/modals.stories.tsx
+++ b/client/src/components/common/modals/modals.stories.tsx
@@ -38,7 +38,7 @@ const inputs = {
 };
 
 const changes = {
-  price: (e: string): void => {
+  price: (e: React.ChangeEvent<HTMLInputElement>): void => {
     console.log(e);
   },
 };

--- a/client/src/components/common/modals/modals.stories.tsx
+++ b/client/src/components/common/modals/modals.stories.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import dummyOptions from '../../../__dummy-data__/components/inputs/dummyOptions';
 import AcoountbookDeleteByAdminModal from './accountbook-delete-by-admin/AccountbookDeleteByAdminModal';
 import FormModalHeader from './form-modal-header/FormModalHeader';
 import TransactionInputList from './form-modal-transaction/TransactionInputList';
@@ -36,6 +37,10 @@ export const FormModalHeaderDefault: React.FC = () => {
 const inputs = {
   price: 1000,
   classify: true,
+  categories: {
+    placeholder: '카테고리',
+    items: dummyOptions,
+  },
 };
 
 const changes = {
@@ -50,12 +55,15 @@ const changes = {
       //
     },
   },
+  categories: (change: string) => {
+    //
+  },
 };
 
 export const TransactionInputListDefault: React.FC = () => {
   return (
-    <div style={{ backgroundColor: 'gray' }}>
-      <TransactionInputList inputs={inputs} changes={changes} />;
+    <div style={{ backgroundColor: '#ECECEC' }}>
+      <TransactionInputList inputs={inputs} changes={changes} />
     </div>
   );
 };

--- a/client/src/constants/color.js
+++ b/client/src/constants/color.js
@@ -5,3 +5,4 @@ export const DEEP_GRAY = '#7f7f7f';
 export const LIGHT_GRAY = '#f6f8fa';
 export const MODAL_GRAY = '#5E5E5E';
 export const MODAL_RED = '#E74C3C';
+export const MODAL_WHITE = '#ECECEC';

--- a/client/src/types/options.ts
+++ b/client/src/types/options.ts
@@ -1,0 +1,5 @@
+export interface Options {
+  value: string;
+  label: string;
+  checked?: boolean;
+}


### PR DESCRIPTION
## 구현 세부 사항
### modal header
![작업1](https://user-images.githubusercontent.com/49854357/100628783-f0d5e900-336b-11eb-9fec-80590e0f3e7a.png)
### input form
![작업 2](https://user-images.githubusercontent.com/49854357/100628793-f2071600-336b-11eb-995e-4fe6fe585cc0.png)
### filter form
![작업3](https://user-images.githubusercontent.com/49854357/100628797-f3384300-336b-11eb-8b07-4f84d23ddc1e.png)

모달에 사용되는 기본적인 form의 View만 작업하였습니다.

## 추가적으로 구현해야할 사항

완전한 modal 조립하기 ( filter, input form)
mobx와 연결하기
transaction 버튼과 조립하기


@boostcamp-2020/accountbook_mentor 

