### PR TITLE
가계부 관리 페이지 좌측 Sidebar 컴포넌트 구현

### DIFF
--- a/client/src/components/common/settings-sidebar/SettingsSidebar.stories.tsx
+++ b/client/src/components/common/settings-sidebar/SettingsSidebar.stories.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import SettingsSidebar from './SettingsSidebar';
+
+export default {
+  title: 'settings-sidebar',
+  component: SettingsSidebar,
+};
+
+export const Default = (): JSX.Element => {
+  return <SettingsSidebar></SettingsSidebar>;
+};

--- a/client/src/components/common/settings-sidebar/SettingsSidebar.stories.tsx
+++ b/client/src/components/common/settings-sidebar/SettingsSidebar.stories.tsx
@@ -7,5 +7,5 @@ export default {
 };
 
 export const Default = (): JSX.Element => {
-  return <SettingsSidebar></SettingsSidebar>;
+  return <SettingsSidebar currentPage={'accountbook'}></SettingsSidebar>;
 };

--- a/client/src/components/common/settings-sidebar/SettingsSidebar.tsx
+++ b/client/src/components/common/settings-sidebar/SettingsSidebar.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import styled from 'styled-components';
+import { GRAY } from '../../../constants/color';
+import SettingsSidebarHeader from './settings-sidebar-header/SettingsSidebarHeader';
+import SettingsSidebarBody from './settings-sidebar-body/SettingsSidebarBody';
+
+const SettingsSidebarWrapper = styled.div`
+  width: 14em;
+  height: 100vh;
+  overflow: auto;
+  position: fixed;
+  top: 0%;
+  left: 0%;
+  background-color: ${GRAY};
+`;
+
+const SettingsSidebar = (): JSX.Element => {
+  return (
+    <SettingsSidebarWrapper>
+      <SettingsSidebarHeader />
+      <SettingsSidebarBody />
+    </SettingsSidebarWrapper>
+  );
+};
+
+export default SettingsSidebar;

--- a/client/src/components/common/settings-sidebar/SettingsSidebar.tsx
+++ b/client/src/components/common/settings-sidebar/SettingsSidebar.tsx
@@ -14,11 +14,15 @@ const SettingsSidebarWrapper = styled.div`
   background-color: ${GRAY};
 `;
 
-const SettingsSidebar = (): JSX.Element => {
+interface SettingsSidebarProps {
+  currentPage: string;
+}
+
+const SettingsSidebar = ({ currentPage }: SettingsSidebarProps): JSX.Element => {
   return (
     <SettingsSidebarWrapper>
       <SettingsSidebarHeader />
-      <SettingsSidebarBody />
+      <SettingsSidebarBody currentPage={currentPage} />
     </SettingsSidebarWrapper>
   );
 };

--- a/client/src/components/common/settings-sidebar/settings-sidebar-body/SettingsSidebarBody.stories.tsx
+++ b/client/src/components/common/settings-sidebar/settings-sidebar-body/SettingsSidebarBody.stories.tsx
@@ -6,6 +6,22 @@ export default {
   component: SettingsSidebarBody,
 };
 
-export const Default = (): JSX.Element => {
-  return <SettingsSidebarBody />;
+export const AccountbookSettingsPage = (): JSX.Element => {
+  return <SettingsSidebarBody currentPage={'accountbook'} />;
+};
+
+export const CategoriesSettingsPage = (): JSX.Element => {
+  return <SettingsSidebarBody currentPage={'categories'} />;
+};
+
+export const AccountsSettingsPage = (): JSX.Element => {
+  return <SettingsSidebarBody currentPage={'accounts'} />;
+};
+
+export const SocialSettingsPage = (): JSX.Element => {
+  return <SettingsSidebarBody currentPage={'social'} />;
+};
+
+export const CsvSettingsPage = (): JSX.Element => {
+  return <SettingsSidebarBody currentPage={'csv'} />;
 };

--- a/client/src/components/common/settings-sidebar/settings-sidebar-body/SettingsSidebarBody.stories.tsx
+++ b/client/src/components/common/settings-sidebar/settings-sidebar-body/SettingsSidebarBody.stories.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import SettingsSidebarBody from './SettingsSidebarBody';
+
+export default {
+  title: 'settings-sidebar/settings-sidebar-body',
+  component: SettingsSidebarBody,
+};
+
+export const Default = (): JSX.Element => {
+  return <SettingsSidebarBody />;
+};

--- a/client/src/components/common/settings-sidebar/settings-sidebar-body/SettingsSidebarBody.tsx
+++ b/client/src/components/common/settings-sidebar/settings-sidebar-body/SettingsSidebarBody.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import styled from 'styled-components';
+import { LIGHT_GRAY, GRAY } from '../../../../constants/color';
+
+const SettingsSidebarBodyWrapper = styled.div`
+  margin: 0 auto;
+  width: 100%;
+  z-index: 1;
+  padding-top: 3em;
+`;
+
+const SettingsSidebarMenuItem = styled.div`
+  padding: 12px 20px;
+  cursor: pointer;
+  font-size: 1.2rem;
+  width: 100%;
+  &:hover {
+    background-color: ${LIGHT_GRAY};
+    border: 1px solid ${GRAY};
+  }
+`;
+
+const SettingsSidebarBody = (): JSX.Element => {
+  return (
+    <SettingsSidebarBodyWrapper>
+      <SettingsSidebarMenuItem>가계부 설정</SettingsSidebarMenuItem>
+      <SettingsSidebarMenuItem>카테고리 관리</SettingsSidebarMenuItem>
+      <SettingsSidebarMenuItem>결제수단 관리</SettingsSidebarMenuItem>
+      <SettingsSidebarMenuItem>소셜</SettingsSidebarMenuItem>
+      <SettingsSidebarMenuItem>CSV 파일 관리</SettingsSidebarMenuItem>
+    </SettingsSidebarBodyWrapper>
+  );
+};
+
+export default SettingsSidebarBody;

--- a/client/src/components/common/settings-sidebar/settings-sidebar-body/SettingsSidebarBody.tsx
+++ b/client/src/components/common/settings-sidebar/settings-sidebar-body/SettingsSidebarBody.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
-import { LIGHT_GRAY, GRAY } from '../../../../constants/color';
+import { LIGHT_GRAY, GRAY, BLUE } from '../../../../constants/color';
 
 const SettingsSidebarBodyWrapper = styled.div`
   margin: 0 auto;
@@ -9,25 +9,53 @@ const SettingsSidebarBodyWrapper = styled.div`
   padding-top: 3em;
 `;
 
-const SettingsSidebarMenuItem = styled.div`
+const SettingsSidebarMenuItem = styled.div<{ currentPage: string }>`
   padding: 12px 20px;
   cursor: pointer;
   font-size: 1.2rem;
   width: 100%;
+
   &:hover {
     background-color: ${LIGHT_GRAY};
     border: 1px solid ${GRAY};
   }
+
+  &:nth-child(1) {
+    color: ${({ currentPage }) => (currentPage == 'accountbook' ? BLUE : 'black')};
+    font-weight: ${({ currentPage }) => (currentPage == 'accountbook' ? 'bold' : 'normal')};
+  }
+  &:nth-child(2) {
+    color: ${({ currentPage }) => (currentPage == 'categories' ? BLUE : 'black')};
+    font-weight: ${({ currentPage }) => (currentPage == 'categories' ? 'bold' : 'normal')};
+  }
+  &:nth-child(3) {
+    color: ${({ currentPage }) => (currentPage == 'accounts' ? BLUE : 'black')};
+    font-weight: ${({ currentPage }) => (currentPage == 'accounts' ? 'bold' : 'normal')};
+  }
+
+  &:nth-child(4) {
+    color: ${({ currentPage }) => (currentPage == 'social' ? BLUE : 'black')};
+    font-weight: ${({ currentPage }) => (currentPage == 'social' ? 'bold' : 'normal')};
+  }
+
+  &:nth-child(5) {
+    color: ${({ currentPage }) => (currentPage == 'csv' ? BLUE : 'black')};
+    font-weight: ${({ currentPage }) => (currentPage == 'csv' ? 'bold' : 'normal')};
+  }
 `;
 
-const SettingsSidebarBody = (): JSX.Element => {
+interface SettingsSidebarBodyProps {
+  currentPage: string;
+}
+
+const SettingsSidebarBody = ({ currentPage }: SettingsSidebarBodyProps): JSX.Element => {
   return (
     <SettingsSidebarBodyWrapper>
-      <SettingsSidebarMenuItem>가계부 설정</SettingsSidebarMenuItem>
-      <SettingsSidebarMenuItem>카테고리 관리</SettingsSidebarMenuItem>
-      <SettingsSidebarMenuItem>결제수단 관리</SettingsSidebarMenuItem>
-      <SettingsSidebarMenuItem>소셜</SettingsSidebarMenuItem>
-      <SettingsSidebarMenuItem>CSV 파일 관리</SettingsSidebarMenuItem>
+      <SettingsSidebarMenuItem currentPage={currentPage}>가계부 설정</SettingsSidebarMenuItem>
+      <SettingsSidebarMenuItem currentPage={currentPage}>카테고리 관리</SettingsSidebarMenuItem>
+      <SettingsSidebarMenuItem currentPage={currentPage}>결제수단 관리</SettingsSidebarMenuItem>
+      <SettingsSidebarMenuItem currentPage={currentPage}>소셜</SettingsSidebarMenuItem>
+      <SettingsSidebarMenuItem currentPage={currentPage}>CSV 파일 관리</SettingsSidebarMenuItem>
     </SettingsSidebarBodyWrapper>
   );
 };

--- a/client/src/components/common/settings-sidebar/settings-sidebar-body/SettingsSidebarBody.tsx
+++ b/client/src/components/common/settings-sidebar/settings-sidebar-body/SettingsSidebarBody.tsx
@@ -9,7 +9,12 @@ const SettingsSidebarBodyWrapper = styled.div`
   padding-top: 3em;
 `;
 
-const SettingsSidebarMenuItem = styled.div<{ currentPage: string }>`
+interface SettingsSidebarMenuItemProps {
+  currentPage: string;
+  onClick?: void;
+}
+
+const SettingsSidebarMenuItem = styled.div<SettingsSidebarMenuItemProps>`
   padding: 12px 20px;
   cursor: pointer;
   font-size: 1.2rem;

--- a/client/src/components/common/settings-sidebar/settings-sidebar-header/SettingsSidebarHeader.stories.tsx
+++ b/client/src/components/common/settings-sidebar/settings-sidebar-header/SettingsSidebarHeader.stories.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import SettingsSidebarHeader from './SettingsSidebarHeader';
+
+export default {
+  title: 'settings-sidebar/settings-sidebar-header',
+  component: SettingsSidebarHeader,
+};
+
+export const Default = (): JSX.Element => {
+  return <SettingsSidebarHeader />;
+};

--- a/client/src/components/common/settings-sidebar/settings-sidebar-header/SettingsSidebarHeader.tsx
+++ b/client/src/components/common/settings-sidebar/settings-sidebar-header/SettingsSidebarHeader.tsx
@@ -10,6 +10,7 @@ const SidebarHeader = styled.div`
   display: flex;
   flex-direction: row;
   align-items: center;
+  padding: 20px;
 `;
 
 const BackButtonWrapper = styled.div`

--- a/client/src/components/common/settings-sidebar/settings-sidebar-header/SettingsSidebarHeader.tsx
+++ b/client/src/components/common/settings-sidebar/settings-sidebar-header/SettingsSidebarHeader.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import styled from 'styled-components';
+import ModalBackButton from '../../back-button/ModalBackButton';
+
+interface SettingsSidebarHeaderProps {
+  goToPreviousPage?: () => void;
+}
+
+const SidebarHeader = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+`;
+
+const BackButtonWrapper = styled.div`
+  cursor: pointer;
+  width: 1.3em;
+  margin-right: 2.5em;
+  margin-left: 0.3em;
+`;
+
+const SettingsTitle = styled.div`
+  padding-top: 0.3em;
+  font-size: 1.4rem;
+`;
+
+const SettingsSidebarHeader = ({ goToPreviousPage }: SettingsSidebarHeaderProps): JSX.Element => {
+  return (
+    <SidebarHeader>
+      <BackButtonWrapper>
+        <ModalBackButton onClick={goToPreviousPage} />
+      </BackButtonWrapper>
+      <SettingsTitle>가계부 관리</SettingsTitle>
+    </SidebarHeader>
+  );
+};
+
+export default SettingsSidebarHeader;


### PR DESCRIPTION
## 관련 이슈
close #80 [공통 컴포넌트] 좌측 사이드바 컴포넌트

## 구현 세부사항 및 수정 사항
- 가계부 관리 페이지 좌측 Sidebar의 Header 컴포넌트 구현
    - SettingsSidebarHeader 컴포넌트는 클릭 시 이전 페이지로 이동하는 ModalBackButton과 페이지 이름인 '가계부 관리'가 포함
    - SettingsSidebarHeader 컴포넌트 스토리 파일 생성
<br>

- 가계부 관리 페이지 좌측 Sidebar의 Body 컴포넌트 구현
    - SettingsSidebarBody 컴포넌트는 클릭 시 해당 메뉴를 설정하는 페이지로 이동하는 SettingsSidebarMenuItem으로 구성
    - SettingsSidebarBody 컴포넌트 스토리 파일 생성
    - SettingsSidebarMenuItem 컴포넌트에 currentPage 속성을 추가하여 현재 페이지에 해당하는 MenuItem 텍스트를 BLUE 색상으로 표시
<br>

- 가계부 관리 페이지 좌측 Sidebar 컴포넌트 구현
    - SettingsSidebarHeader와 SettingsSidebarBody 컴포넌트를 합쳐서 SettingsSidebar 컴포넌트 생성
<br>


## 데모영상
![화면-기록-2020-12-01-오후-3 29 29](https://user-images.githubusercontent.com/42263086/100705443-8adc7680-33ea-11eb-8d92-4721fa2db524.gif)
<br>


## 기타사항
- HeaderNavigation 컴포넌트 구현 코드 참고하여 작업
<br>

@boostcamp-2020/accountbook_mentor 


