### PR TITLE
필터링 기능 구현

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -13978,11 +13978,6 @@
       "resolved": "https://registry.npmjs.org/mobx-react-lite/-/mobx-react-lite-3.1.6.tgz",
       "integrity": "sha512-MM3x9BLt5nC7iE/ILA5n2+hfrplEKYbFjqROEuGkzBdZP/KD+Z44+2gseczRrTG0xFuiPWfEzgT68+6/zqOiEw=="
     },
-    "mobx-utils": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/mobx-utils/-/mobx-utils-6.0.1.tgz",
-      "integrity": "sha512-0p5xqHDt/arz3cswVcEHYKY/BwL+fifsNroT3Gjkz9lNC7ZDsJm3IuGsmYlvFcVRJRr1rwlFZGuZXrt/MhHEJQ=="
-    },
     "move-concurrently": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
@@ -14256,6 +14251,22 @@
         "prepend-http": "^1.0.0",
         "query-string": "^4.1.0",
         "sort-keys": "^1.0.0"
+      },
+      "dependencies": {
+        "query-string": {
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/query-string/-/query-string-4.3.4.tgz",
+          "integrity": "sha1-u7aTucqRXCMlFbIosaArYJBD2+s=",
+          "requires": {
+            "object-assign": "^4.1.0",
+            "strict-uri-encode": "^1.0.0"
+          }
+        },
+        "strict-uri-encode": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
+          "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM="
+        }
       }
     },
     "npm-run-path": {
@@ -16271,12 +16282,13 @@
       "integrity": "sha512-j48ZBT5IZbSqJiSU8EX4XrN8nXiflHvmMvv2XpFc31gh7n6EpSs75bNr6+oj3FOLWyT8m09pTmqLNl34L7/uPQ=="
     },
     "query-string": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-4.3.4.tgz",
-      "integrity": "sha1-u7aTucqRXCMlFbIosaArYJBD2+s=",
+      "version": "6.13.7",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.13.7.tgz",
+      "integrity": "sha512-CsGs8ZYb39zu0WLkeOhe0NMePqgYdAuCqxOYKDR5LVCytDZYMGx3Bb+xypvQvPHVPijRXB0HZNFllCzHRe4gEA==",
       "requires": {
-        "object-assign": "^4.1.0",
-        "strict-uri-encode": "^1.0.0"
+        "decode-uri-component": "^0.2.0",
+        "split-on-first": "^1.0.0",
+        "strict-uri-encode": "^2.0.0"
       }
     },
     "querystring": {
@@ -18697,6 +18709,11 @@
         "wbuf": "^1.7.3"
       }
     },
+    "split-on-first": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz",
+      "integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw=="
+    },
     "split-string": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
@@ -18884,9 +18901,9 @@
       "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ=="
     },
     "strict-uri-encode": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
-      "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
+      "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY="
     },
     "string-length": {
       "version": "4.0.1",

--- a/client/package.json
+++ b/client/package.json
@@ -15,6 +15,7 @@
     "axios": "^0.21.0",
     "mobx": "^6.0.4",
     "mobx-react": "^7.0.5",
+    "query-string": "^6.13.7",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "react-input-color": "^3.0.1",

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -13,7 +13,7 @@ function App(): JSX.Element {
           <GlobalFonts />
           <Switch>
             <Route exact path="/login" component={LoginPage} />
-            <Route exact path="/accountbooks/:id/transactions" component={TransactionPage} />
+            <Route exact path="/accountbooks/:id" component={TransactionPage} />
           </Switch>
         </Router>
       </RootProvider>

--- a/client/src/components/common/not-found-transaction/NotFoundTransaction.tsx
+++ b/client/src/components/common/not-found-transaction/NotFoundTransaction.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import styled from 'styled-components';
+
+const Wrapper = styled.div`
+  position: fixed;
+  top: 45%;
+  left: calc(50% - 150px);
+  width: 300px;
+  height: 100%;
+  margin: auto;
+  text-align: center;
+`;
+
+const NotFoundTransaction: React.FC = () => {
+  return (
+    <Wrapper>
+      <svg width="48" height="48" viewBox="0 0 24 24" fill="gray">
+        <path d="M0 0h24v24H0z" fill="none" />
+        <path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z" />
+      </svg>
+      <h3>거래 내역이 없습니다.</h3>
+    </Wrapper>
+  );
+};
+
+export default NotFoundTransaction;

--- a/client/src/components/common/not-found-transaction/NotFoundTrransaction.stories.tsx
+++ b/client/src/components/common/not-found-transaction/NotFoundTrransaction.stories.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import NotFoundTransaction from './NotFoundTransaction';
+import styled from 'styled-components';
+
+export default {
+  title: 'common/not-found-transaction/NotFoundTransaction',
+  component: NotFoundTransaction,
+};
+
+export const Default: React.FC = () => {
+  return <NotFoundTransaction />;
+};

--- a/client/src/components/common/spinner/Spinner.stories.tsx
+++ b/client/src/components/common/spinner/Spinner.stories.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import Spinner from './Spinner';
+
+export default {
+  title: 'common/spinner/Spinner',
+  component: Spinner,
+};
+
+export const Default = (): JSX.Element => {
+  return <Spinner />;
+};

--- a/client/src/components/common/spinner/Spinner.tsx
+++ b/client/src/components/common/spinner/Spinner.tsx
@@ -4,8 +4,8 @@ import styled from 'styled-components';
 const Wrapper = styled.div`
   text-align: center;
   position: absolute;
-  left: 48%;
-  top: 42%;
+  left: 47%;
+  top: 43%;
 `;
 
 const Spinner = (): JSX.Element => (

--- a/client/src/components/common/spinner/Spinner.tsx
+++ b/client/src/components/common/spinner/Spinner.tsx
@@ -4,8 +4,8 @@ import styled from 'styled-components';
 const Wrapper = styled.div`
   text-align: center;
   position: absolute;
-  left: 47%;
-  top: 43%;
+  left: calc(50% - 32px);
+  top: calc(50% - 32px);
 `;
 
 const Spinner = (): JSX.Element => (

--- a/client/src/components/common/spinner/Spinner.tsx
+++ b/client/src/components/common/spinner/Spinner.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import styled from 'styled-components';
+
+const Wrapper = styled.div`
+  text-align: center;
+  position: absolute;
+  left: 48%;
+  top: 42%;
+`;
+
+const Spinner = (): JSX.Element => (
+  <Wrapper>
+    <svg width="64" height="64" viewBox="0 0 38 38" xmlns="http://www.w3.org/2000/svg" stroke="#666666">
+      <g fill="none" fillRule="evenodd">
+        <g transform="translate(1 1)" strokeWidth="2">
+          <circle strokeOpacity=".5" cx="18" cy="18" r="18" />
+          <path d="M36 18c0-9.94-8.06-18-18-18">
+            <animateTransform
+              attributeName="transform"
+              type="rotate"
+              from="0 18 18"
+              to="360 18 18"
+              dur="1s"
+              repeatCount="indefinite"
+            />
+          </path>
+        </g>
+      </g>
+    </svg>
+  </Wrapper>
+);
+
+export default Spinner;

--- a/client/src/components/common/transactions/all-transaction-container/AllTransactionContainer.tsx
+++ b/client/src/components/common/transactions/all-transaction-container/AllTransactionContainer.tsx
@@ -3,6 +3,7 @@ import DayTransactionContainer from '../day-transaction-container/DayTransaction
 import Income, { isIncome } from '../../../../types/income';
 import Expenditure from '../../../../types/expenditure';
 import NotFoundTransaction from '../../not-found-transaction/NotFoundTransaction';
+import { useObserver } from 'mobx-react';
 
 interface Props {
   transactions: Array<Income | Expenditure>;

--- a/client/src/components/common/transactions/all-transaction-container/AllTransactionContainer.tsx
+++ b/client/src/components/common/transactions/all-transaction-container/AllTransactionContainer.tsx
@@ -2,6 +2,7 @@ import React, { memo } from 'react';
 import DayTransactionContainer from '../day-transaction-container/DayTransactionContainer';
 import Income, { isIncome } from '../../../../types/income';
 import Expenditure from '../../../../types/expenditure';
+import NotFoundTransaction from '../../not-found-transaction/NotFoundTransaction';
 
 interface Props {
   transactions: Array<Income | Expenditure>;
@@ -35,6 +36,8 @@ const AllTransactionContainer = ({ transactions }: Props): JSX.Element => {
     beforeMonth = currentMonth;
     beforeDay = currentDay;
   });
+
+  if (transactions.length == 0) return <NotFoundTransaction />;
 
   return (
     <>

--- a/client/src/components/common/transactions/all-transaction-container/AllTransactionContainer.tsx
+++ b/client/src/components/common/transactions/all-transaction-container/AllTransactionContainer.tsx
@@ -4,12 +4,15 @@ import Income, { isIncome } from '../../../../types/income';
 import Expenditure from '../../../../types/expenditure';
 import NotFoundTransaction from '../../not-found-transaction/NotFoundTransaction';
 import { useObserver } from 'mobx-react';
+import Spinner from '../../spinner/Spinner';
+import useStore from '../../../../hook/use-store/useStore';
 
 interface Props {
   transactions: Array<Income | Expenditure>;
 }
 
 const AllTransactionContainer = ({ transactions }: Props): JSX.Element => {
+  const { rootStore } = useStore();
   transactions.sort((transaction1, transaction2) => {
     return new Date(transaction2.date).getTime() - new Date(transaction1.date).getTime();
   });
@@ -38,6 +41,7 @@ const AllTransactionContainer = ({ transactions }: Props): JSX.Element => {
     beforeDay = currentDay;
   });
 
+  if (rootStore.loading) return <Spinner />;
   if (transactions.length == 0) return <NotFoundTransaction />;
 
   return (

--- a/client/src/components/common/transactions/all-transaction-container/AllTransactionContainer.tsx
+++ b/client/src/components/common/transactions/all-transaction-container/AllTransactionContainer.tsx
@@ -1,4 +1,4 @@
-import React, { memo } from 'react';
+import React, { memo, useContext } from 'react';
 import DayTransactionContainer from '../day-transaction-container/DayTransactionContainer';
 import Income, { isIncome } from '../../../../types/income';
 import Expenditure from '../../../../types/expenditure';
@@ -12,7 +12,7 @@ interface Props {
 }
 
 const AllTransactionContainer = ({ transactions }: Props): JSX.Element => {
-  const { rootStore } = useStore();
+  const { transactionStore } = useStore().rootStore;
   transactions.sort((transaction1, transaction2) => {
     return new Date(transaction2.date).getTime() - new Date(transaction1.date).getTime();
   });
@@ -41,7 +41,7 @@ const AllTransactionContainer = ({ transactions }: Props): JSX.Element => {
     beforeDay = currentDay;
   });
 
-  if (rootStore.loading) return <Spinner />;
+  if (transactionStore.loading) return <Spinner />;
   if (transactions.length == 0) return <NotFoundTransaction />;
 
   return (

--- a/client/src/components/common/transactions/all-transaction-container/AllTransactionContainer.tsx
+++ b/client/src/components/common/transactions/all-transaction-container/AllTransactionContainer.tsx
@@ -41,7 +41,7 @@ const AllTransactionContainer = ({ transactions }: Props): JSX.Element => {
     beforeDay = currentDay;
   });
 
-  if (transactionStore.loading) return <Spinner />;
+  if (transactionStore.isLoading) return <Spinner />;
   if (transactions.length == 0) return <NotFoundTransaction />;
 
   return (

--- a/client/src/components/common/transactions/day-transaction-container/DayTransactionContainer.tsx
+++ b/client/src/components/common/transactions/day-transaction-container/DayTransactionContainer.tsx
@@ -5,6 +5,7 @@ import Expenditure from '../../../../types/expenditure';
 import { numberWithCommas } from '../../../../utils/number';
 import { RED, BLUE, GRAY } from '../../../../constants/color';
 import TransactionItem from '../transaction-item/TransactionItem';
+import useStore from '../../../../hook/use-store/useStore';
 
 const Container = styled.div`
   display: flex;
@@ -44,6 +45,8 @@ interface Props {
 const days = ['일요일', '월요일', '화요일', '수요일', '목요일', '금요일', '토요일'];
 
 const DayTransactionContainer = ({ transactions }: Props): JSX.Element => {
+  const { transactionStore } = useStore().rootStore;
+  const month = new Date(transactions[0].date).getMonth() + 1;
   const date = new Date(transactions[0].date).getDate();
   const day = days[new Date(transactions[0].date).getDay()];
   const totalAmount = transactions.reduce((sum, transaction) => {
@@ -54,6 +57,7 @@ const DayTransactionContainer = ({ transactions }: Props): JSX.Element => {
     <Container>
       <DayTransactionHeader totalAmount={totalAmount}>
         <div className="header-item">
+          {transactionStore.filterMode && `${month}월`}&nbsp;
           {date}일 {day}
         </div>
         <div className="header-item"></div>

--- a/client/src/components/common/transactions/day-transaction-container/DayTransactionContainer.tsx
+++ b/client/src/components/common/transactions/day-transaction-container/DayTransactionContainer.tsx
@@ -57,7 +57,7 @@ const DayTransactionContainer = ({ transactions }: Props): JSX.Element => {
     <Container>
       <DayTransactionHeader totalAmount={totalAmount}>
         <div className="header-item">
-          {transactionStore.filterMode && `${month}월`}&nbsp;
+          {transactionStore.isFilterMode && `${month}월`}&nbsp;
           {date}일 {day}
         </div>
         <div className="header-item"></div>

--- a/client/src/components/login-button/naver-login-button/NaverLoginButton.stories.tsx
+++ b/client/src/components/login-button/naver-login-button/NaverLoginButton.stories.tsx
@@ -7,9 +7,9 @@ export default {
 };
 
 export const LargeButton = (): JSX.Element => {
-  return <LargeNaverLoginButton width={200} />;
+  return <LargeNaverLoginButton />;
 };
 
 export const SmallButton = (): JSX.Element => {
-  return <SmallNaverLoginButton width={200} />;
+  return <SmallNaverLoginButton />;
 };

--- a/client/src/pages/transaction-page/TransactionPage.tsx
+++ b/client/src/pages/transaction-page/TransactionPage.tsx
@@ -1,20 +1,27 @@
 import React from 'react';
 import { match } from 'react-router-dom';
+import { Location } from 'history';
 import TransactionView from './TransactionView';
 import styled from 'styled-components';
+import queryString from 'query-string';
 
 interface Props {
   match: match<{ id: string }>;
+  location: Location;
 }
 
 const PageWrapper = styled.div`
   font-family: 'Spoqa Han Sans';
 `;
 
-const TransactionPage: React.FC<Props> = ({ match }: Props) => {
+interface Query {
+  category: string | string[] | null;
+}
+const TransactionPage: React.FC<Props> = ({ match, location }: Props) => {
+  const query = location.search ? queryString.parse(location.search) : null;
   return (
     <PageWrapper>
-      <TransactionView accountbookId={Number(match.params.id)} />
+      <TransactionView accountbookId={Number(match.params.id)} query={query} />
     </PageWrapper>
   );
 };

--- a/client/src/pages/transaction-page/TransactionView.stories.tsx
+++ b/client/src/pages/transaction-page/TransactionView.stories.tsx
@@ -11,7 +11,7 @@ export default {
 export const Default: React.FC = () => {
   return (
     <RootProvider>
-      <TransactionView accountbookId={1} />
+      <TransactionView accountbookId={1} query={null} />
     </RootProvider>
   );
 };

--- a/client/src/pages/transaction-page/TransactionView.tsx
+++ b/client/src/pages/transaction-page/TransactionView.tsx
@@ -49,7 +49,7 @@ interface Props {
 const TransactionView: React.FC<Props> = ({ accountbookId, query }: Props) => {
   const { rootStore } = useStore();
   const { dateStore, transactionStore } = rootStore;
-
+  console.log('hi');
   useEffect(() => {
     if (!query) {
       transactionStore.findTransactions(accountbookId, dateStore.startDate, dateStore.endDate);

--- a/client/src/pages/transaction-page/TransactionView.tsx
+++ b/client/src/pages/transaction-page/TransactionView.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
 import Sidebar from '../../components/common/sidebar/Sidebar';
 import HeaderNavigation from '../../components/common/header-navigation/HeaderNavigation';
@@ -10,6 +10,10 @@ import MenuNavigation from '../../components/common/menu-navigation/MenuNavigati
 import useStore from '../../hook/use-store/useStore';
 import { useObserver } from 'mobx-react';
 import { isIncome } from '../../types/income';
+import { ParsedQuery } from 'query-string';
+import Spinner from '../../components/common/spinner/Spinner';
+import { filtering } from '../../utils/filter';
+import { runInAction } from 'mobx';
 
 const ViewWrapper = styled.div`
   width: 70%;
@@ -39,13 +43,27 @@ const AmountWrapper = styled.div`
 
 interface Props {
   accountbookId: number;
+  query: ParsedQuery<string> | null;
 }
 
-const TransactionView: React.FC<Props> = ({ accountbookId }: Props) => {
-  const { dateStore, transactionStore } = useStore().rootStore;
+const TransactionView: React.FC<Props> = ({ accountbookId, query }: Props) => {
+  const { rootStore } = useStore();
+  const { dateStore, transactionStore } = rootStore;
 
   useEffect(() => {
-    transactionStore.findTransactions(accountbookId, dateStore.startDate, dateStore.endDate);
+    if (!query) {
+      transactionStore.findTransactions(accountbookId, dateStore.startDate, dateStore.endDate);
+      return;
+    }
+
+    const { start_date, end_date, account, income_category, expenditure_category } = query;
+    transactionStore.filterTransactions(accountbookId, {
+      startDate: start_date,
+      endDate: end_date,
+      account: account,
+      incomeCategory: income_category,
+      expenditureCategory: expenditure_category,
+    });
   }, []);
 
   let totalIncome = 0;

--- a/client/src/pages/transaction-page/TransactionView.tsx
+++ b/client/src/pages/transaction-page/TransactionView.tsx
@@ -49,7 +49,7 @@ interface Props {
 const TransactionView: React.FC<Props> = ({ accountbookId, query }: Props) => {
   const { rootStore } = useStore();
   const { dateStore, transactionStore } = rootStore;
-  console.log('hi');
+
   useEffect(() => {
     if (!query) {
       transactionStore.findTransactions(accountbookId, dateStore.startDate, dateStore.endDate);

--- a/client/src/pages/transaction-page/TransactionView.tsx
+++ b/client/src/pages/transaction-page/TransactionView.tsx
@@ -11,9 +11,6 @@ import useStore from '../../hook/use-store/useStore';
 import { useObserver } from 'mobx-react';
 import { isIncome } from '../../types/income';
 import { ParsedQuery } from 'query-string';
-import Spinner from '../../components/common/spinner/Spinner';
-import { filtering } from '../../utils/filter';
-import { runInAction } from 'mobx';
 
 const ViewWrapper = styled.div`
   width: 70%;

--- a/client/src/store/RootStore.tsx
+++ b/client/src/store/RootStore.tsx
@@ -1,14 +1,22 @@
+import { action } from 'mobx';
 import React, { createContext } from 'react';
 import DateStore from './DateStore';
 import TransactionStore from './TransactionStore';
+import { observable } from 'mobx';
 
 export default class RootStore {
+  @observable loading = true;
   dateStore;
   transactionStore;
 
   constructor() {
     this.dateStore = new DateStore(this);
     this.transactionStore = new TransactionStore(this);
+  }
+
+  @action
+  setLoading(status: boolean): void {
+    this.loading = status;
   }
 }
 

--- a/client/src/store/RootStore.tsx
+++ b/client/src/store/RootStore.tsx
@@ -5,18 +5,12 @@ import TransactionStore from './TransactionStore';
 import { observable } from 'mobx';
 
 export default class RootStore {
-  @observable loading = true;
   dateStore;
   transactionStore;
 
   constructor() {
     this.dateStore = new DateStore(this);
     this.transactionStore = new TransactionStore(this);
-  }
-
-  @action
-  setLoading(status: boolean): void {
-    this.loading = status;
   }
 }
 

--- a/client/src/store/TransactionStore.tsx
+++ b/client/src/store/TransactionStore.tsx
@@ -27,6 +27,7 @@ export default class TransactionStore {
     const transactions = await getTransactions(accountbookId, startDate, endDate);
     runInAction(() => {
       this.transactions = transactions;
+      this.rootStore.setLoading(false);
     });
   }
 
@@ -38,6 +39,7 @@ export default class TransactionStore {
     await this.findTransactions(accountbookId, new Date(startDate as string), new Date(endDate as string));
     runInAction(() => {
       this.transactions = filtering(this.transactions, { account, incomeCategory, expenditureCategory });
+      this.rootStore.setLoading(false);
     });
   }
 }

--- a/client/src/store/TransactionStore.tsx
+++ b/client/src/store/TransactionStore.tsx
@@ -16,7 +16,7 @@ interface Query {
 export default class TransactionStore {
   @observable transactions: Array<Income | Expenditure> = [];
   @observable filterMode = false;
-  @observable loading = true;
+  @observable isLoading = true;
   rootStore;
 
   constructor(rootStore: RootStore) {
@@ -29,7 +29,7 @@ export default class TransactionStore {
     const transactions = await getTransactions(accountbookId, startDate, endDate);
     runInAction(() => {
       this.transactions = transactions;
-      this.setLoading(false);
+      this.isLoading = false;
     });
   }
 
@@ -42,12 +42,7 @@ export default class TransactionStore {
     runInAction(() => {
       this.transactions = filtering(this.transactions, { account, incomeCategory, expenditureCategory });
       this.filterMode = true;
-      this.setLoading(false);
+      this.isLoading = false;
     });
-  }
-
-  @action
-  setLoading(status: boolean): void {
-    this.loading = status;
   }
 }

--- a/client/src/store/TransactionStore.tsx
+++ b/client/src/store/TransactionStore.tsx
@@ -27,7 +27,7 @@ export default class TransactionStore {
     const transactions = await getTransactions(accountbookId, startDate, endDate);
     runInAction(() => {
       this.transactions = transactions;
-      this.rootStore.setLoading(false);
+      //this.rootStore.setLoading(false);
     });
   }
 

--- a/client/src/store/TransactionStore.tsx
+++ b/client/src/store/TransactionStore.tsx
@@ -1,9 +1,17 @@
-import { observable, makeObservable, runInAction, action } from 'mobx';
-import React, { createContext } from 'react';
+import { observable, makeObservable, runInAction, action, computed } from 'mobx';
 import Income from '../types/income';
 import Expenditure from '../types/expenditure';
 import { getTransactions } from '../services/transaction';
 import RootStore from './RootStore';
+import { filtering } from '../utils/filter';
+
+interface Query {
+  startDate: string | string[] | null;
+  endDate: string | string[] | null;
+  incomeCategory: string | string[] | null;
+  expenditureCategory: string | string[] | null;
+  account: string | string[] | null;
+}
 
 export default class TransactionStore {
   @observable transactions: Array<Income | Expenditure> = [];
@@ -19,6 +27,17 @@ export default class TransactionStore {
     const transactions = await getTransactions(accountbookId, startDate, endDate);
     runInAction(() => {
       this.transactions = transactions;
+    });
+  }
+
+  @action
+  async filterTransactions(
+    accountbookId: number,
+    { startDate, endDate, incomeCategory, expenditureCategory, account }: Query,
+  ): Promise<void> {
+    await this.findTransactions(accountbookId, new Date(startDate as string), new Date(endDate as string));
+    runInAction(() => {
+      this.transactions = filtering(this.transactions, { account, incomeCategory, expenditureCategory });
     });
   }
 }

--- a/client/src/store/TransactionStore.tsx
+++ b/client/src/store/TransactionStore.tsx
@@ -16,6 +16,7 @@ interface Query {
 export default class TransactionStore {
   @observable transactions: Array<Income | Expenditure> = [];
   @observable filterMode = false;
+  @observable loading = true;
   rootStore;
 
   constructor(rootStore: RootStore) {
@@ -28,7 +29,7 @@ export default class TransactionStore {
     const transactions = await getTransactions(accountbookId, startDate, endDate);
     runInAction(() => {
       this.transactions = transactions;
-      this.rootStore.setLoading(false);
+      this.setLoading(false);
     });
   }
 
@@ -41,7 +42,12 @@ export default class TransactionStore {
     runInAction(() => {
       this.transactions = filtering(this.transactions, { account, incomeCategory, expenditureCategory });
       this.filterMode = true;
-      this.rootStore.setLoading(false);
+      this.setLoading(false);
     });
+  }
+
+  @action
+  setLoading(status: boolean): void {
+    this.loading = status;
   }
 }

--- a/client/src/store/TransactionStore.tsx
+++ b/client/src/store/TransactionStore.tsx
@@ -15,7 +15,7 @@ interface Query {
 
 export default class TransactionStore {
   @observable transactions: Array<Income | Expenditure> = [];
-  @observable filterMode = false;
+  @observable isFilterMode = false;
   @observable isLoading = true;
   rootStore;
 
@@ -41,7 +41,7 @@ export default class TransactionStore {
     await this.findTransactions(accountbookId, new Date(startDate as string), new Date(endDate as string));
     runInAction(() => {
       this.transactions = filtering(this.transactions, { account, incomeCategory, expenditureCategory });
-      this.filterMode = true;
+      this.isFilterMode = true;
       this.isLoading = false;
     });
   }

--- a/client/src/store/TransactionStore.tsx
+++ b/client/src/store/TransactionStore.tsx
@@ -15,6 +15,7 @@ interface Query {
 
 export default class TransactionStore {
   @observable transactions: Array<Income | Expenditure> = [];
+  @observable filterMode = false;
   rootStore;
 
   constructor(rootStore: RootStore) {
@@ -39,6 +40,7 @@ export default class TransactionStore {
     await this.findTransactions(accountbookId, new Date(startDate as string), new Date(endDate as string));
     runInAction(() => {
       this.transactions = filtering(this.transactions, { account, incomeCategory, expenditureCategory });
+      this.filterMode = true;
       this.rootStore.setLoading(false);
     });
   }

--- a/client/src/store/TransactionStore.tsx
+++ b/client/src/store/TransactionStore.tsx
@@ -27,7 +27,7 @@ export default class TransactionStore {
     const transactions = await getTransactions(accountbookId, startDate, endDate);
     runInAction(() => {
       this.transactions = transactions;
-      //this.rootStore.setLoading(false);
+      this.rootStore.setLoading(false);
     });
   }
 

--- a/client/src/utils/filter.ts
+++ b/client/src/utils/filter.ts
@@ -1,0 +1,80 @@
+import Income from '../types/income';
+import Expenditure from '../types/expenditure';
+
+interface Query {
+  incomeCategory: string | string[] | null;
+  expenditureCategory: string | string[] | null;
+  account: string | string[] | null;
+}
+
+export const filtering = (
+  transactions: Array<Income | Expenditure>,
+  { incomeCategory, expenditureCategory, account }: Query,
+): Array<Income | Expenditure> => {
+  let filteredTransactions: Array<Income | Expenditure> = [];
+
+  if ((!incomeCategory && !expenditureCategory) || !account) {
+    return [];
+  }
+
+  if (incomeCategory) {
+    const incomeCategories = (incomeCategory as string).split(' ');
+    let filteredList = incomeCategoryFilter(transactions, incomeCategories);
+
+    const accounts = (account as string).split(' ');
+    filteredList = accountFilter(filteredList, accounts);
+
+    filteredTransactions = [...filteredTransactions, ...filteredList];
+  }
+
+  if (expenditureCategory) {
+    const expenditureCategories = (expenditureCategory as string).split(' ');
+    let filteredList = expenditureCategoryFilter(transactions, expenditureCategories);
+
+    const accounts = (account as string).split(' ');
+    filteredList = accountFilter(filteredList, accounts);
+
+    filteredTransactions = [...filteredTransactions, ...filteredList];
+  }
+
+  return filteredTransactions as Array<Income | Expenditure>;
+};
+
+const incomeCategoryFilter = (
+  transactions: Array<Income | Expenditure>,
+  incomeCategories: Array<string>,
+): Array<Income | Expenditure> => {
+  const filteredTransactions = transactions.filter((transaction) => {
+    const pass = incomeCategories.some((category) => {
+      return transaction.category.name === category;
+    });
+    return pass;
+  });
+  return filteredTransactions;
+};
+
+const expenditureCategoryFilter = (
+  transactions: Array<Income | Expenditure>,
+  expenditureCategories: Array<string>,
+): Array<Income | Expenditure> => {
+  const filteredTransactions = transactions.filter((transaction) => {
+    const pass = expenditureCategories.some((category) => {
+      return transaction.category.name === category;
+    });
+    return pass;
+  });
+  return filteredTransactions;
+};
+
+const accountFilter = (
+  transactions: Array<Income | Expenditure>,
+  accounts: Array<string>,
+): Array<Income | Expenditure> => {
+  const filteredTransactions = transactions.filter((transaction) => {
+    const pass = accounts.some((account) => {
+      return transaction.account.name === account;
+    });
+    return pass;
+  });
+  return filteredTransactions;
+};

--- a/client/src/utils/filter.ts
+++ b/client/src/utils/filter.ts
@@ -37,7 +37,7 @@ export const filtering = (
     filteredTransactions = [...filteredTransactions, ...filteredList];
   }
 
-  return filteredTransactions as Array<Income | Expenditure>;
+  return filteredTransactions;
 };
 
 const incomeCategoryFilter = (


### PR DESCRIPTION
## 관련 이슈
[가계부 내역 페이지] 필터링 기능 구현 #151

## 구현/수정 내용

- 내역이 없을 때 보여줄 UI 구현
- 내역페이지 스피너 적용
- 쿼리스트링이 있는지 없는지 판단하여 있다면 필터링하여 렌더링을, 없다면 월 단위로 렌더링 하도록 구현
- 필터링을 안했을 때는 일과 요일만 표시하고 필터링을 했을 때는 월,일,요일을 표시하도록 구현

## 추가로 구현해야 할 사항
- 필터링 적용 시 기존의 월변경 기능을 없애고 필터링 옵션을 렌더링 해주기
- 필터링 모달 만들기
- 쿼리스트링 생성하는 로직 구현하기

## 필터링 설계
```
필터링 버튼을 누르면 아래와 같은 url 형식으로 요청을 보낸다.
accountbooks/:id?start_date=&end_date=&income_category=&expenditure_category=&account=&

옵션이 여러개일 경우 +로 이어붙인다.
ex) income_category=쇼핑+여가+영화

필터링 조건은 or 가 아니라 and 이다.
따라서 아래와 같은 조건에서 필터링된 항목의 개수는 0개이다.

ex) 결제수단을 하나라도 선택하지 않은 경우
ex) 수입 또는 지출 카테고리를 하나라도 선택하지 않은 경우
```

## 내역이 없을 때 보여줄 UI
![image](https://user-images.githubusercontent.com/26829633/100735673-f5a2a780-3414-11eb-8407-4d09ba479b95.png)


## Spinner 적용
![image](https://user-images.githubusercontent.com/26829633/100740762-9052b480-341c-11eb-87b5-68e9156c8d62.png)


## 필터링 결과
`http://localhost:3000/accountbooks/1?start_date=2020.01.01&end_date=2021.01.01&expenditure_category=&account=현금+농협&income_category=급여` 로 필터

![image](https://user-images.githubusercontent.com/26829633/100737932-3354ff80-3418-11eb-90a0-8570caf2551e.png)

@boostcamp-2020/accountbook_mentor 