### PR TITLE
accountbook 테이블 스키마 변경, 카카오 oauth 로그인 시 프로필 사진 없을 때 버그 수정

### DIFF
--- a/server/src/models/accountbook.js
+++ b/server/src/models/accountbook.js
@@ -7,7 +7,7 @@ module.exports = (sequelize, DataTypes) => {
         allowNull: false,
       },
       gmt: {
-        type: DataTypes.STRING,
+        type: DataTypes.INTEGER,
         allowNull: false,
       },
       startDay: {

--- a/server/src/services/oauth.js
+++ b/server/src/services/oauth.js
@@ -42,7 +42,7 @@ const getUserInfo = async (code, state, config) => {
       provider: config.provider,
       email: data.kakao_account.email,
       nickname: data.kakao_account.email.match(/^[0-9a-zA-Z]([-_.]?[0-9a-zA-Z])*@/g)[0].replace('@', ''),
-      profileUrl: data.properties.profile_image,
+      profileUrl: data.properties.profile_image ? data.properties.profile_image : 'https://i.imgur.com/0kGli9o.jpg',
     };
   }
   return userInfo;


### PR DESCRIPTION
### 구현 세부사항 
- accountbook의 gmt 속성이 string으로 되어 있던 걸 integer로 변경했습니다.
- 카카오로 OAuth 로그인할 때, 프로필 사진이 없으면 프로필 url이 undefined로 오는 것을 확인했습니다. undefined일 경우 미리 지정한 default url을 사용할 수 있도록 수정하였습니다.

@boostcamp-2020/accountbook_mentor 
