### PR TITLE
내역 수정,삭제 API 구현

### DIFF
--- a/server/src/api/controllers/transaction.js
+++ b/server/src/api/controllers/transaction.js
@@ -21,8 +21,16 @@ const createExpenditureTransaction = async (ctx) => {
   ctx.body = createdExpenditure;
 };
 
+const updateIncomeTransaction = async (ctx) => {
+  const { id } = ctx.request.params;
+  const incomeData = ctx.request.body;
+  const income = await transactionService.updateIncome(id, incomeData);
+  ctx.body = income;
+};
+
 module.exports = {
   findTransactions,
   createIncomeTransaction,
   createExpenditureTransaction,
+  updateIncomeTransaction,
 };

--- a/server/src/api/controllers/transaction.js
+++ b/server/src/api/controllers/transaction.js
@@ -35,10 +35,17 @@ const updateExpenditureTransaction = async (ctx) => {
   ctx.body = expenditure;
 };
 
+const deleteIncomeTransaction = async (ctx) => {
+  const { id } = ctx.request.params;
+  await transactionService.deleteIncomeById(id);
+  ctx.status = 204;
+};
+
 module.exports = {
   findTransactions,
   createIncomeTransaction,
   createExpenditureTransaction,
   updateIncomeTransaction,
   updateExpenditureTransaction,
+  deleteIncomeTransaction,
 };

--- a/server/src/api/controllers/transaction.js
+++ b/server/src/api/controllers/transaction.js
@@ -1,4 +1,5 @@
 const transactionService = require('@services/transaction');
+const transaction = require('../../services/transaction');
 
 const findTransactions = async (ctx) => {
   // eslint-disable-next-line camelcase
@@ -41,6 +42,12 @@ const deleteIncomeTransaction = async (ctx) => {
   ctx.status = 204;
 };
 
+const deleteExpenditureTransaction = async (ctx) => {
+  const { id } = ctx.request.params;
+  await transactionService.deleteExpenditureById(id);
+  ctx.status = 204;
+};
+
 module.exports = {
   findTransactions,
   createIncomeTransaction,
@@ -48,4 +55,5 @@ module.exports = {
   updateIncomeTransaction,
   updateExpenditureTransaction,
   deleteIncomeTransaction,
+  deleteExpenditureTransaction,
 };

--- a/server/src/api/controllers/transaction.js
+++ b/server/src/api/controllers/transaction.js
@@ -28,9 +28,17 @@ const updateIncomeTransaction = async (ctx) => {
   ctx.body = income;
 };
 
+const updateExpenditureTransaction = async (ctx) => {
+  const { id } = ctx.request.params;
+  const expenditureData = ctx.request.body;
+  const expenditure = await transactionService.updateExpenditure(id, expenditureData);
+  ctx.body = expenditure;
+};
+
 module.exports = {
   findTransactions,
   createIncomeTransaction,
   createExpenditureTransaction,
   updateIncomeTransaction,
+  updateExpenditureTransaction,
 };

--- a/server/src/api/controllers/transaction.js
+++ b/server/src/api/controllers/transaction.js
@@ -1,5 +1,4 @@
 const transactionService = require('@services/transaction');
-const transaction = require('../../services/transaction');
 
 const findTransactions = async (ctx) => {
   // eslint-disable-next-line camelcase

--- a/server/src/api/routes/transaction.js
+++ b/server/src/api/routes/transaction.js
@@ -8,4 +8,5 @@ router.post('/income', transactionController.createIncomeTransaction);
 router.post('/expenditure', transactionController.createExpenditureTransaction);
 router.patch('/income/:id', transactionController.updateIncomeTransaction);
 router.patch('/expenditure/:id', transactionController.updateExpenditureTransaction);
+router.delete('/income/:id', transactionController.deleteIncomeTransaction);
 module.exports = router;

--- a/server/src/api/routes/transaction.js
+++ b/server/src/api/routes/transaction.js
@@ -7,4 +7,5 @@ router.get('/', transactionController.findTransactions);
 router.post('/income', transactionController.createIncomeTransaction);
 router.post('/expenditure', transactionController.createExpenditureTransaction);
 router.patch('/income/:id', transactionController.updateIncomeTransaction);
+router.patch('/expenditure/:id', transactionController.updateExpenditureTransaction);
 module.exports = router;

--- a/server/src/api/routes/transaction.js
+++ b/server/src/api/routes/transaction.js
@@ -9,4 +9,5 @@ router.post('/expenditure', transactionController.createExpenditureTransaction);
 router.patch('/income/:id', transactionController.updateIncomeTransaction);
 router.patch('/expenditure/:id', transactionController.updateExpenditureTransaction);
 router.delete('/income/:id', transactionController.deleteIncomeTransaction);
+router.delete('/expenditure/:id', transactionController.deleteExpenditureTransaction);
 module.exports = router;

--- a/server/src/api/routes/transaction.js
+++ b/server/src/api/routes/transaction.js
@@ -6,5 +6,5 @@ const router = new Router();
 router.get('/', transactionController.findTransactions);
 router.post('/income', transactionController.createIncomeTransaction);
 router.post('/expenditure', transactionController.createExpenditureTransaction);
-
+router.patch('/income/:id', transactionController.updateIncomeTransaction);
 module.exports = router;

--- a/server/src/services/transaction.js
+++ b/server/src/services/transaction.js
@@ -164,6 +164,10 @@ const updateExpenditure = async (expenditureId, { expenditureCategoryId, account
   return expenditure;
 };
 
+const deleteIncomeById = async (id) => {
+  await db.income.destroy({ where: { id } });
+};
+
 module.exports = {
   findIncomes,
   findExpenditures,
@@ -171,4 +175,5 @@ module.exports = {
   createExpenditure,
   updateIncome,
   updateExpenditure,
+  deleteIncomeById,
 };

--- a/server/src/services/transaction.js
+++ b/server/src/services/transaction.js
@@ -24,6 +24,28 @@ const findIncomeById = async (id) => {
   return income;
 };
 
+const findExpenditureById = async (id) => {
+  const expenditure = await db.expenditure.findOne({
+    attributes: ['id', 'amount', 'place', 'date', 'memo'],
+    where: {
+      id,
+    },
+    include: [
+      {
+        model: db.expenditureCategory,
+        as: 'category',
+        attributes: ['id', 'name', 'color'],
+      },
+      {
+        model: db.account,
+        attributes: ['id', 'name', 'color'],
+      },
+    ],
+  });
+
+  return expenditure;
+};
+
 const findIncomes = async (accountbookId, startDate, endDate) => {
   const incomes = await db.income.findAll({
     attributes: ['id', 'amount', 'content', 'date', 'memo'],
@@ -104,24 +126,7 @@ const createExpenditure = async ({ accountbookId, expenditureCategoryId, account
     accountId,
   });
 
-  const createdExpenditure = await db.expenditure.findOne({
-    attributes: ['id', 'amount', 'place', 'date', 'memo'],
-    where: {
-      id: expenditure.id,
-    },
-    include: [
-      {
-        model: db.expenditureCategory,
-        as: 'category',
-        attributes: ['id', 'name', 'color'],
-      },
-      {
-        model: db.account,
-        attributes: ['id', 'name', 'color'],
-      },
-    ],
-  });
-
+  const createdExpenditure = await findExpenditureById(expenditure.id);
   return createdExpenditure;
 };
 
@@ -142,10 +147,28 @@ const updateIncome = async (incomeId, { incomeCategoryId, accountId, amount, con
   return income;
 };
 
+const updateExpenditure = async (expenditureId, { expenditureCategoryId, accountId, amount, place, date, memo }) => {
+  await db.expenditure.update(
+    {
+      expenditureCategoryId,
+      accountId,
+      amount,
+      place,
+      date,
+      memo,
+    },
+    { where: { id: expenditureId } },
+  );
+
+  const expenditure = await findExpenditureById(expenditureId);
+  return expenditure;
+};
+
 module.exports = {
   findIncomes,
   findExpenditures,
   createIncome,
   createExpenditure,
   updateIncome,
+  updateExpenditure,
 };

--- a/server/src/services/transaction.js
+++ b/server/src/services/transaction.js
@@ -2,6 +2,28 @@ const db = require('@models');
 const { Op } = require('sequelize');
 const { getAccountbookById } = require('@services/accountbook');
 
+const findIncomeById = async (id) => {
+  const income = await db.income.findOne({
+    attributes: ['id', 'amount', 'content', 'date', 'memo'],
+    where: {
+      id,
+    },
+    include: [
+      {
+        model: db.incomeCategory,
+        as: 'category',
+        attributes: ['id', 'name', 'color'],
+      },
+      {
+        model: db.account,
+        attributes: ['id', 'name', 'color'],
+      },
+    ],
+  });
+
+  return income;
+};
+
 const findIncomes = async (accountbookId, startDate, endDate) => {
   const incomes = await db.income.findAll({
     attributes: ['id', 'amount', 'content', 'date', 'memo'],
@@ -66,24 +88,7 @@ const createIncome = async ({ accountbookId, incomeCategoryId, accountId, amount
     accountId,
   });
 
-  const createdIncome = await db.income.findOne({
-    attributes: ['id', 'amount', 'content', 'date', 'memo'],
-    where: {
-      id: income.id,
-    },
-    include: [
-      {
-        model: db.incomeCategory,
-        as: 'category',
-        attributes: ['id', 'name', 'color'],
-      },
-      {
-        model: db.account,
-        attributes: ['id', 'name', 'color'],
-      },
-    ],
-  });
-
+  const createdIncome = await findIncomeById(income.id);
   return createdIncome;
 };
 
@@ -120,9 +125,27 @@ const createExpenditure = async ({ accountbookId, expenditureCategoryId, account
   return createdExpenditure;
 };
 
+const updateIncome = async (incomeId, { incomeCategoryId, accountId, amount, content, date, memo }) => {
+  await db.income.update(
+    {
+      incomeCategoryId,
+      accountId,
+      amount,
+      content,
+      date,
+      memo,
+    },
+    { where: { id: incomeId } },
+  );
+
+  const income = await findIncomeById(incomeId);
+  return income;
+};
+
 module.exports = {
   findIncomes,
   findExpenditures,
   createIncome,
   createExpenditure,
+  updateIncome,
 };

--- a/server/src/services/transaction.js
+++ b/server/src/services/transaction.js
@@ -168,6 +168,10 @@ const deleteIncomeById = async (id) => {
   await db.income.destroy({ where: { id } });
 };
 
+const deleteExpenditureById = async (id) => {
+  await db.expenditure.destroy({ where: { id } });
+};
+
 module.exports = {
   findIncomes,
   findExpenditures,
@@ -176,4 +180,5 @@ module.exports = {
   updateIncome,
   updateExpenditure,
   deleteIncomeById,
+  deleteExpenditureById,
 };


### PR DESCRIPTION
## 관련 이슈
close #193 수입 내역 수정 API
close #194 지출 내역 수정 API 구현
close #195 수입 내역 삭제 API 구현
close #196 지출 내역 삭제 API 구현

## 구현/수정 내용
- 수입 내역 수정 API를 구현하였습니다.
- 지출 내역 수정 API를 구현하였습니다.
- 수입 내역 삭제 API를 구현하였습니다.
- 지출 내역 삭제 API를 구현하였습니다.
- 특정 지출/수입을 조회하는 로직이 반복되어 함수로 분리하였습니다.
- API Docs를 수정하였습니다.

@boostcamp-2020/accountbook_mentor 
