### PR TITLE
카테고리 수정 모달창, 결제수단 수정 모달창 구현 및 관련 BE 작업

### DIFF
--- a/client/src/components/common/account/Account.tsx
+++ b/client/src/components/common/account/Account.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
 import { getTextColor } from '../../../utils/color';
+import useStore from '../../../hook/use-store/useStore';
 
 const AccountWrapper = styled.div<{ bgColor: string; textColor: string; shadow?: boolean }>`
   width: 17vw;
@@ -28,10 +29,17 @@ interface AccountProps {
   onClick?: () => void;
 }
 
-const Account = ({ text, bgColor, shadow, onClick }: AccountProps): JSX.Element => {
+const Account = ({ text, bgColor, shadow }: AccountProps): JSX.Element => {
+  const { rootStore } = useStore();
+  const updateAccountForm = rootStore.modalStore.updateAccountFormStore;
+
+  const openUpdateAccountForm = (): void => {
+    updateAccountForm.toggleShow();
+  };
+
   const textColor = getTextColor(bgColor);
   return (
-    <AccountWrapper bgColor={bgColor} textColor={textColor} shadow={shadow} onClick={onClick}>
+    <AccountWrapper bgColor={bgColor} textColor={textColor} shadow={shadow} onClick={openUpdateAccountForm}>
       {text}
     </AccountWrapper>
   );

--- a/client/src/components/common/add-category-button/AddCategoryButton.stories.tsx
+++ b/client/src/components/common/add-category-button/AddCategoryButton.stories.tsx
@@ -7,5 +7,8 @@ export default {
 };
 
 export const AddCategoryButtonDefault = (): JSX.Element => {
-  return <AddCategoryButton />;
+  const onClick = (): void => {
+    // Props가 없어서 발생하는 오류 때문에 임의로 만든 함수
+  };
+  return <AddCategoryButton onClick={onClick} />;
 };

--- a/client/src/components/common/add-category-button/AddCategoryButton.tsx
+++ b/client/src/components/common/add-category-button/AddCategoryButton.tsx
@@ -3,8 +3,9 @@ import useStore from '../../../hook/use-store/useStore';
 import styled from 'styled-components';
 import PlusInCircle from '../plus-in-circle/PlusInCircle';
 import { GRAY } from '../../../constants/color';
+import { observer } from 'mobx-react';
 
-const CategoryWrapper = styled.div`
+const CategoryWrapper = styled.div<{ flag?: boolean }>`
   width: 100%;
   max-width: 115px;
   height: 100%;
@@ -26,12 +27,17 @@ const PlusInCircleWrapper = styled.div`
   margin: auto 0;
 `;
 
-const AddCategoryButton: React.FC = () => {
+interface AddCategoryButton {
+  onClick: () => void;
+}
+
+const AddCategoryButton: React.FC<AddCategoryButton> = ({ onClick }: AddCategoryButton) => {
   const { rootStore } = useStore();
   const createCategoryForm = rootStore.modalStore.createCategoryFormStore;
 
   const openCreateCategoryForm = (): void => {
     createCategoryForm.toggleShow();
+    onClick();
   };
 
   return (
@@ -43,4 +49,4 @@ const AddCategoryButton: React.FC = () => {
   );
 };
 
-export default AddCategoryButton;
+export default observer(AddCategoryButton);

--- a/client/src/components/common/category/Category.tsx
+++ b/client/src/components/common/category/Category.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
 import { getTextColor } from '../../../utils/color';
+import useStore from '../../../hook/use-store/useStore';
 
 const CategoryWrapper = styled.div<{ bgColor: string; textColor: string; shadow?: boolean }>`
   width: 100%;
@@ -31,9 +32,16 @@ interface CategoryProps {
 }
 
 const Category = ({ text, bgColor, shadow, onClick }: CategoryProps): JSX.Element => {
+  const { rootStore } = useStore();
+  const updateCategoryForm = rootStore.modalStore.updateCategoryFormStore;
+
+  const openUpdateCategoryForm = (): void => {
+    updateCategoryForm.toggleShow();
+  };
+
   const textColor = getTextColor(bgColor);
   return (
-    <CategoryWrapper bgColor={bgColor} textColor={textColor} shadow={shadow} onClick={onClick}>
+    <CategoryWrapper bgColor={bgColor} textColor={textColor} shadow={shadow} onClick={openUpdateCategoryForm}>
       {text}
     </CategoryWrapper>
   );

--- a/client/src/components/common/modals/form-modal-account/FormModalCreateAccount.tsx
+++ b/client/src/components/common/modals/form-modal-account/FormModalCreateAccount.tsx
@@ -57,13 +57,8 @@ const FormModalAccount: React.FC = () => {
           <AccountPreview title={name} color={inputColor} onChange={onChange} />
         </FormModalItem>
         <FormModalItem>
-          <FormModalLabel>{formModal.CreateAccountLabelName}</FormModalLabel>
-          <InputText
-            maxLength={8}
-            placeholder={formModal.CreateAccountPlaceholder}
-            value={name}
-            onChange={onChangeName}
-          />
+          <FormModalLabel>{formModal.AccountLabelName}</FormModalLabel>
+          <InputText maxLength={8} placeholder={formModal.AccountPlaceholder} value={name} onChange={onChangeName} />
         </FormModalItem>
       </FormModalWrapper>
     </ModalBackground>

--- a/client/src/components/common/modals/form-modal-account/FormModalCreateAccount.tsx
+++ b/client/src/components/common/modals/form-modal-account/FormModalCreateAccount.tsx
@@ -9,9 +9,12 @@ import { observer } from 'mobx-react';
 import AccountPreview from '../../account-preview/AccountPreview';
 import InputText from '../../inputs/input-text/InputText';
 import formModal from '../../../../constants/formModal';
+import useGetParam from '../../../../hook/use-get-param/useGetParam';
+import { convertToAccount } from '../formUtils';
 
 const FormModalAccount: React.FC = () => {
   const { rootStore } = useStore();
+  const id = useGetParam();
   const toggle = rootStore.modalStore.createAccountFormStore;
 
   const [name, setName] = useState<string>('부스트카드');
@@ -30,10 +33,26 @@ const FormModalAccount: React.FC = () => {
     toggle.toggleShow();
   };
 
+  const onCreate = () => {
+    try {
+      const account = convertToAccount(id, name, inputColor);
+      rootStore.accountStore.createAccount(account);
+    } catch (e) {
+      alert(e.message);
+    } finally {
+      modalToggle();
+    }
+  };
+
   return (
     <ModalBackground show={show} closeModal={modalToggle}>
       <FormModalWrapper>
-        <FormModalHeader modalName={formModal.CreateAccountModalName} blueName={'생성'} closeModal={modalToggle} />
+        <FormModalHeader
+          modalName={formModal.CreateAccountModalName}
+          blueName={'생성'}
+          closeModal={modalToggle}
+          clickBlue={onCreate}
+        />
         <FormModalItem>
           <AccountPreview title={name} color={inputColor} onChange={onChange} />
         </FormModalItem>

--- a/client/src/components/common/modals/form-modal-account/FormModalCreateAccount.tsx
+++ b/client/src/components/common/modals/form-modal-account/FormModalCreateAccount.tsx
@@ -11,6 +11,7 @@ import InputText from '../../inputs/input-text/InputText';
 import formModal from '../../../../constants/formModal';
 import useGetParam from '../../../../hook/use-get-param/useGetParam';
 import { convertToAccount } from '../formUtils';
+import { BLACK } from '../../../../constants/color';
 
 const FormModalAccount: React.FC = () => {
   const { rootStore } = useStore();
@@ -18,7 +19,7 @@ const FormModalAccount: React.FC = () => {
   const toggle = rootStore.modalStore.createAccountFormStore;
 
   const [name, setName] = useState<string>('부스트카드');
-  const [inputColor, setInputColor] = useState<string>('#000000');
+  const [inputColor, setInputColor] = useState<string>(BLACK);
 
   const onChangeName = (e: React.ChangeEvent<HTMLInputElement>) => {
     setName(e.target.value);

--- a/client/src/components/common/modals/form-modal-account/FormModalUpdateAccount.tsx
+++ b/client/src/components/common/modals/form-modal-account/FormModalUpdateAccount.tsx
@@ -9,13 +9,14 @@ import { observer } from 'mobx-react';
 import AccountPreview from '../../account-preview/AccountPreview';
 import InputText from '../../inputs/input-text/InputText';
 import formModal from '../../../../constants/formModal';
+import { BLACK } from '../../../../constants/color';
 
 const FormModalUpdateAccount: React.FC = () => {
   const { rootStore } = useStore();
   const toggle = rootStore.modalStore.updateAccountFormStore;
 
   const [name, setName] = useState<string>('부스트카드');
-  const [inputColor, setInputColor] = useState<string>('#000000');
+  const [inputColor, setInputColor] = useState<string>(BLACK);
 
   const onChangeName = (e: React.ChangeEvent<HTMLInputElement>) => {
     setName(e.target.value);

--- a/client/src/components/common/modals/form-modal-account/FormModalUpdateAccount.tsx
+++ b/client/src/components/common/modals/form-modal-account/FormModalUpdateAccount.tsx
@@ -1,0 +1,54 @@
+import React, { useState } from 'react';
+import useStore from '../../../../hook/use-store/useStore';
+import FormModalWrapper from '../form-modal-template/FormModalWrapper';
+import FormModalItem from '../form-modal-template/FormModalItemWrapper';
+import FormModalLabel from '../form-modal-template/FormModalLabel';
+import ModalBackground from '../modal-background/ModalBackground';
+import FormModalHeader from '../form-modal-header/FormModalHeader';
+import { observer } from 'mobx-react';
+import AccountPreview from '../../account-preview/AccountPreview';
+import InputText from '../../inputs/input-text/InputText';
+import formModal from '../../../../constants/formModal';
+
+const FormModalUpdateAccount: React.FC = () => {
+  const { rootStore } = useStore();
+  const toggle = rootStore.modalStore.updateAccountFormStore;
+
+  const [name, setName] = useState<string>('부스트카드');
+  const [inputColor, setInputColor] = useState<string>('#000000');
+
+  const onChangeName = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setName(e.target.value);
+  };
+
+  const onChange = (color: { hex: string }): void => {
+    setInputColor(color.hex);
+  };
+
+  const { show } = toggle;
+  const modalToggle = (): void => {
+    toggle.toggleShow();
+  };
+
+  return (
+    <ModalBackground show={show} closeModal={modalToggle}>
+      <FormModalWrapper>
+        <FormModalHeader
+          modalName={formModal.UpdateAccountModalName}
+          blueName={'완료'}
+          redName={'삭제'}
+          closeModal={modalToggle}
+        />
+        <FormModalItem>
+          <AccountPreview title={name} color={inputColor} onChange={onChange} />
+        </FormModalItem>
+        <FormModalItem>
+          <FormModalLabel>{formModal.AccountLabelName}</FormModalLabel>
+          <InputText maxLength={8} placeholder={formModal.AccountPlaceholder} value={name} onChange={onChangeName} />
+        </FormModalItem>
+      </FormModalWrapper>
+    </ModalBackground>
+  );
+};
+
+export default observer(FormModalUpdateAccount);

--- a/client/src/components/common/modals/form-modal-category/FormModalCreateCategory.tsx
+++ b/client/src/components/common/modals/form-modal-category/FormModalCreateCategory.tsx
@@ -9,9 +9,12 @@ import { observer } from 'mobx-react';
 import CategoryPreview from '../../category-preview/CategoryPreview';
 import InputText from '../../inputs/input-text/InputText';
 import formModal from '../../../../constants/formModal';
+import useGetParam from '../../../../hook/use-get-param/useGetParam';
+import { convertToCategory } from '../formUtils';
 
 const FormModalCategory: React.FC = () => {
   const { rootStore } = useStore();
+  const id = useGetParam();
   const toggle = rootStore.modalStore.createCategoryFormStore;
 
   const [name, setName] = useState<string>('카테고리 1');
@@ -30,10 +33,37 @@ const FormModalCategory: React.FC = () => {
     toggle.toggleShow();
   };
 
+  const onCreateIncomeCategory = () => {
+    try {
+      const incomeCategory = convertToCategory(id, name, inputColor);
+      rootStore.categoryStore.createIncomeCategory(incomeCategory);
+    } catch (e) {
+      alert(e.message);
+    } finally {
+      modalToggle();
+    }
+  };
+
+  const onCreateExpenditureCategory = () => {
+    try {
+      const expenditureCategory = convertToCategory(id, name, inputColor);
+      rootStore.categoryStore.createExpenditureCategory(expenditureCategory);
+    } catch (e) {
+      alert(e.message);
+    } finally {
+      modalToggle();
+    }
+  };
+
   return (
     <ModalBackground show={show} closeModal={modalToggle}>
       <FormModalWrapper>
-        <FormModalHeader modalName={formModal.CreateCategoryModalName} blueName={'생성'} closeModal={modalToggle} />
+        <FormModalHeader
+          modalName={formModal.CreateCategoryModalName}
+          blueName={'생성'}
+          closeModal={modalToggle}
+          clickBlue={toggle.incomeFlag ? onCreateIncomeCategory : onCreateExpenditureCategory}
+        />
         <FormModalItem>
           <CategoryPreview title={name} color={inputColor} onChange={onChange} />
         </FormModalItem>

--- a/client/src/components/common/modals/form-modal-category/FormModalCreateCategory.tsx
+++ b/client/src/components/common/modals/form-modal-category/FormModalCreateCategory.tsx
@@ -11,6 +11,7 @@ import InputText from '../../inputs/input-text/InputText';
 import formModal from '../../../../constants/formModal';
 import useGetParam from '../../../../hook/use-get-param/useGetParam';
 import { convertToCategory } from '../formUtils';
+import { BLACK } from '../../../../constants/color';
 
 const FormModalCategory: React.FC = () => {
   const { rootStore } = useStore();
@@ -18,7 +19,7 @@ const FormModalCategory: React.FC = () => {
   const toggle = rootStore.modalStore.createCategoryFormStore;
 
   const [name, setName] = useState<string>('카테고리 1');
-  const [inputColor, setInputColor] = useState<string>('#000000');
+  const [inputColor, setInputColor] = useState<string>(BLACK);
 
   const onChangeName = (e: React.ChangeEvent<HTMLInputElement>) => {
     setName(e.target.value);

--- a/client/src/components/common/modals/form-modal-category/FormModalCreateCategory.tsx
+++ b/client/src/components/common/modals/form-modal-category/FormModalCreateCategory.tsx
@@ -68,13 +68,8 @@ const FormModalCategory: React.FC = () => {
           <CategoryPreview title={name} color={inputColor} onChange={onChange} />
         </FormModalItem>
         <FormModalItem>
-          <FormModalLabel>{formModal.CreateCategoryLabelName}</FormModalLabel>
-          <InputText
-            maxLength={8}
-            placeholder={formModal.CreateCategoryPlaceholder}
-            value={name}
-            onChange={onChangeName}
-          />
+          <FormModalLabel>{formModal.CategoryLabelName}</FormModalLabel>
+          <InputText maxLength={8} placeholder={formModal.CategoryPlaceholder} value={name} onChange={onChangeName} />
         </FormModalItem>
       </FormModalWrapper>
     </ModalBackground>

--- a/client/src/components/common/modals/form-modal-category/FormModalUpdateCategory.tsx
+++ b/client/src/components/common/modals/form-modal-category/FormModalUpdateCategory.tsx
@@ -1,0 +1,56 @@
+import React, { useState } from 'react';
+import useStore from '../../../../hook/use-store/useStore';
+import FormModalWrapper from '../form-modal-template/FormModalWrapper';
+import FormModalItem from '../form-modal-template/FormModalItemWrapper';
+import FormModalLabel from '../form-modal-template/FormModalLabel';
+import ModalBackground from '../modal-background/ModalBackground';
+import FormModalHeader from '../form-modal-header/FormModalHeader';
+import { observer } from 'mobx-react';
+import CategoryPreview from '../../category-preview/CategoryPreview';
+import InputText from '../../inputs/input-text/InputText';
+import formModal from '../../../../constants/formModal';
+
+const FormModalUpdateCategory: React.FC = () => {
+  const { rootStore } = useStore();
+  const toggle = rootStore.modalStore.updateCategoryFormStore;
+
+  const [name, setName] = useState<string>('카테고리 1');
+  const [inputColor, setInputColor] = useState<string>('#000000');
+
+  const onChangeName = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setName(e.target.value);
+  };
+
+  const onChange = (color: { hex: string }): void => {
+    setInputColor(color.hex);
+  };
+
+  const { show } = toggle;
+  const modalToggle = (): void => {
+    toggle.toggleShow();
+  };
+
+  return (
+    <ModalBackground show={show} closeModal={modalToggle}>
+      <FormModalWrapper>
+        <FormModalHeader
+          modalName={formModal.UpdateCategorytModalName}
+          blueName={'완료'}
+          redName={'삭제'}
+          closeModal={modalToggle}
+          // TODO: 카테고리 변경 로직 구현 필요
+          // clickBlue={toggle.incomeFlag ? onCreateIncomeCategory : onCreateExpenditureCategory}
+        />
+        <FormModalItem>
+          <CategoryPreview title={name} color={inputColor} onChange={onChange} />
+        </FormModalItem>
+        <FormModalItem>
+          <FormModalLabel>{formModal.CategoryLabelName}</FormModalLabel>
+          <InputText maxLength={8} placeholder={formModal.CategoryPlaceholder} value={name} onChange={onChangeName} />
+        </FormModalItem>
+      </FormModalWrapper>
+    </ModalBackground>
+  );
+};
+
+export default observer(FormModalUpdateCategory);

--- a/client/src/components/common/modals/form-modal-category/FormModalUpdateCategory.tsx
+++ b/client/src/components/common/modals/form-modal-category/FormModalUpdateCategory.tsx
@@ -9,13 +9,14 @@ import { observer } from 'mobx-react';
 import CategoryPreview from '../../category-preview/CategoryPreview';
 import InputText from '../../inputs/input-text/InputText';
 import formModal from '../../../../constants/formModal';
+import { BLACK } from '../../../../constants/color';
 
 const FormModalUpdateCategory: React.FC = () => {
   const { rootStore } = useStore();
   const toggle = rootStore.modalStore.updateCategoryFormStore;
 
   const [name, setName] = useState<string>('카테고리 1');
-  const [inputColor, setInputColor] = useState<string>('#000000');
+  const [inputColor, setInputColor] = useState<string>(BLACK);
 
   const onChangeName = (e: React.ChangeEvent<HTMLInputElement>) => {
     setName(e.target.value);

--- a/client/src/components/common/modals/formUtils.ts
+++ b/client/src/components/common/modals/formUtils.ts
@@ -3,6 +3,7 @@ import { ExpenditureRequest } from '../../../types/expenditure';
 import { ITransaction } from '../../../types/lineChartValue';
 import { ITransactionForm } from '../../../types/TransactionForm';
 import { privateEncrypt } from 'crypto';
+import { AccountRequest } from '../../../types/account';
 
 export const convertToIncome = (incomeInput: ITransactionForm, accountbookId: number): IncomeRequest => {
   const { price, categories, accounts, content, date, memo } = incomeInput;
@@ -34,5 +35,12 @@ export const convertToExpenditure = (expenditureInput: ITransactionForm, account
     place: content,
     date,
     memo,
+  };
+};
+export const convertToAccount = (accountbookId: number, name: string, color: string): AccountRequest => {
+  return {
+    accountbookId,
+    name,
+    color,
   };
 };

--- a/client/src/components/common/modals/formUtils.ts
+++ b/client/src/components/common/modals/formUtils.ts
@@ -45,17 +45,17 @@ export const convertToAccount = (accountbookId: number, name: string, color: str
     color,
   };
 };
-export const convertToIncomeCategory = (accountbookId: number, name: string, color: string): CategoryRequest => {
+export const convertToCategory = (accountbookId: number, name: string, color: string): CategoryRequest => {
   return {
     accountbookId,
     name,
     color,
   };
 };
-export const convertToExpenditureCategory = (accountbookId: number, name: string, color: string): CategoryRequest => {
-  return {
-    accountbookId,
-    name,
-    color,
-  };
-};
+// export const convertToExpenditureCategory = (accountbookId: number, name: string, color: string): CategoryRequest => {
+//   return {
+//     accountbookId,
+//     name,
+//     color,
+//   };
+// };

--- a/client/src/components/common/modals/formUtils.ts
+++ b/client/src/components/common/modals/formUtils.ts
@@ -4,6 +4,7 @@ import { ITransaction } from '../../../types/lineChartValue';
 import { ITransactionForm } from '../../../types/TransactionForm';
 import { privateEncrypt } from 'crypto';
 import { AccountRequest } from '../../../types/account';
+import { CategoryRequest } from '../../../types/category';
 
 export const convertToIncome = (incomeInput: ITransactionForm, accountbookId: number): IncomeRequest => {
   const { price, categories, accounts, content, date, memo } = incomeInput;
@@ -38,6 +39,20 @@ export const convertToExpenditure = (expenditureInput: ITransactionForm, account
   };
 };
 export const convertToAccount = (accountbookId: number, name: string, color: string): AccountRequest => {
+  return {
+    accountbookId,
+    name,
+    color,
+  };
+};
+export const convertToIncomeCategory = (accountbookId: number, name: string, color: string): CategoryRequest => {
+  return {
+    accountbookId,
+    name,
+    color,
+  };
+};
+export const convertToExpenditureCategory = (accountbookId: number, name: string, color: string): CategoryRequest => {
   return {
     accountbookId,
     name,

--- a/client/src/components/common/modals/modals.stories.tsx
+++ b/client/src/components/common/modals/modals.stories.tsx
@@ -11,6 +11,7 @@ import FormModalTransaction from './form-modal-transaction/FormModalCreateTransa
 import FormModalAccount from './form-modal-account/FormModalCreateAccount';
 import FormModalCategory from './form-modal-category/FormModalCreateCategory';
 import FormModalUpdateAccount from './form-modal-account/FormModalUpdateAccount';
+import FormModalUpdateCategory from './form-modal-category/FormModalUpdateCategory';
 import styled from 'styled-components';
 
 export default {
@@ -85,4 +86,8 @@ export const FormModalCategoryDefault: React.FC = () => {
 
 export const FormModalUpdateAccountDefault: React.FC = () => {
   return <FormModalUpdateAccount />;
+};
+
+export const FormModalUpdateCategoryDefault: React.FC = () => {
+  return <FormModalUpdateCategory />;
 };

--- a/client/src/components/common/modals/modals.stories.tsx
+++ b/client/src/components/common/modals/modals.stories.tsx
@@ -10,6 +10,7 @@ import { inputs as filterInputs, changes as filterChanges } from '../../../__dum
 import FormModalTransaction from './form-modal-transaction/FormModalCreateTransaction';
 import FormModalAccount from './form-modal-account/FormModalCreateAccount';
 import FormModalCategory from './form-modal-category/FormModalCreateCategory';
+import FormModalUpdateAccount from './form-modal-account/FormModalUpdateAccount';
 import styled from 'styled-components';
 
 export default {
@@ -80,4 +81,8 @@ export const FormModalAccountDefault: React.FC = () => {
 
 export const FormModalCategoryDefault: React.FC = () => {
   return <FormModalCategory />;
+};
+
+export const FormModalUpdateAccountDefault: React.FC = () => {
+  return <FormModalUpdateAccount />;
 };

--- a/client/src/constants/color.ts
+++ b/client/src/constants/color.ts
@@ -9,6 +9,7 @@ export const MODAL_RED = '#E74C3C';
 export const MODAL_WHITE = '#ECECEC';
 export const DODGER_BLUE = '#1E90FF';
 export const LIGHT_GREEN = '#11CD6E';
+export const BLACK = '#000000';
 
 const color = {
   BLUE,
@@ -22,6 +23,7 @@ const color = {
   MODAL_WHITE,
   DODGER_BLUE,
   LIGHT_GREEN,
+  BLACK,
 };
 
 export default color;

--- a/client/src/constants/formModal.ts
+++ b/client/src/constants/formModal.ts
@@ -5,6 +5,7 @@ export const CreateCategoryModalName = '카테고리 생성';
 export const AccountLabelName = '결제수단 이름';
 export const CategoryLabelName = '카테고리 이름';
 export const UpdateAccountModalName = '결제수단 편집';
+export const UpdateCategorytModalName = '카테고리 편집';
 
 const formModal = {
   AccountPlaceholder,
@@ -14,6 +15,7 @@ const formModal = {
   AccountLabelName,
   CategoryLabelName,
   UpdateAccountModalName,
+  UpdateCategorytModalName,
 };
 
 export default formModal;

--- a/client/src/constants/formModal.ts
+++ b/client/src/constants/formModal.ts
@@ -1,17 +1,19 @@
-export const CreateAccountPlaceholder = '최대 8자의 결제수단명을 입력해주세요.';
-export const CreateCategoryPlaceholder = '최근 1주일';
+export const AccountPlaceholder = '최대 8글자의 결제수단명을 입력해주세요.';
+export const CategoryPlaceholder = '최대 8글자의 카테고리명을 입력해주세요.';
 export const CreateAccountModalName = '결제수단 생성';
 export const CreateCategoryModalName = '카테고리 생성';
-export const CreateAccountLabelName = '결제수단 이름';
-export const CreateCategoryLabelName = '카테고리 이름';
+export const AccountLabelName = '결제수단 이름';
+export const CategoryLabelName = '카테고리 이름';
+export const UpdateAccountModalName = '결제수단 편집';
 
 const formModal = {
-  CreateAccountPlaceholder,
-  CreateCategoryPlaceholder,
+  AccountPlaceholder,
+  CategoryPlaceholder,
   CreateAccountModalName,
   CreateCategoryModalName,
-  CreateAccountLabelName,
-  CreateCategoryLabelName,
+  AccountLabelName,
+  CategoryLabelName,
+  UpdateAccountModalName,
 };
 
 export default formModal;

--- a/client/src/pages/settings-accounts-page/SettingsAccountsView.tsx
+++ b/client/src/pages/settings-accounts-page/SettingsAccountsView.tsx
@@ -62,10 +62,10 @@ const SettingsAccountsView: React.FC<Props> = ({ accountbookId }: Props) => {
       <SettingsItemWrapper>
         <Label>결제수단 관리</Label>
         <AccountWrapper>
-          {AccountsItems}
           <AccountItemWrapper>
             <AddAccountButton />
           </AccountItemWrapper>
+          {AccountsItems}
         </AccountWrapper>
       </SettingsItemWrapper>
     </SettingsAccountViewWrapper>

--- a/client/src/pages/settings-accounts-page/SettingsAccountsView.tsx
+++ b/client/src/pages/settings-accounts-page/SettingsAccountsView.tsx
@@ -5,6 +5,7 @@ import AddAccountButton from '../../components/common/add-account-button/AddAcco
 import useStore from '../../hook/use-store/useStore';
 import { observer } from 'mobx-react';
 import FormModalAccount from '../../components/common/modals/form-modal-account/FormModalCreateAccount';
+import FormModalUpdateAccount from '../../components/common/modals/form-modal-account/FormModalUpdateAccount';
 
 const SettingsAccountViewWrapper = styled.div`
   position: absolute;
@@ -59,6 +60,7 @@ const SettingsAccountsView: React.FC<Props> = ({ accountbookId }: Props) => {
   return (
     <SettingsAccountViewWrapper>
       <FormModalAccount />
+      <FormModalUpdateAccount />
       <SettingsItemWrapper>
         <Label>결제수단 관리</Label>
         <AccountWrapper>

--- a/client/src/pages/settings-categories-page/SettingsCategoriesView.tsx
+++ b/client/src/pages/settings-categories-page/SettingsCategoriesView.tsx
@@ -68,19 +68,19 @@ const SettingsCategoriesView: React.FC<Props> = ({ accountbookId }: Props) => {
       <SettingsItemWrapper>
         <Label>지출</Label>
         <CategoryWrapper>
-          {ExpenditureCategoryItems}
           <CategoryItemWrapper>
             <AddCategoryButton />
           </CategoryItemWrapper>
+          {ExpenditureCategoryItems}
         </CategoryWrapper>
       </SettingsItemWrapper>
       <SettingsItemWrapper>
         <Label>수입</Label>
         <CategoryWrapper>
-          {IncomeCategoryItems}
           <CategoryItemWrapper>
             <AddCategoryButton />
           </CategoryItemWrapper>
+          {IncomeCategoryItems}
         </CategoryWrapper>
       </SettingsItemWrapper>
     </SettingsCategoryViewWrapper>

--- a/client/src/pages/settings-categories-page/SettingsCategoriesView.tsx
+++ b/client/src/pages/settings-categories-page/SettingsCategoriesView.tsx
@@ -44,6 +44,7 @@ interface Props {
 const SettingsCategoriesView: React.FC<Props> = ({ accountbookId }: Props) => {
   const { rootStore } = useStore();
   const { categoryStore } = rootStore;
+  const createCategoryFormStore = rootStore.modalStore.createCategoryFormStore;
 
   useEffect(() => {
     categoryStore.updateIncomeCategories(accountbookId);
@@ -62,6 +63,14 @@ const SettingsCategoriesView: React.FC<Props> = ({ accountbookId }: Props) => {
     </CategoryItemWrapper>
   ));
 
+  const setIncomeFlagTrue = (): void => {
+    createCategoryFormStore.setIncomeFlagTrue();
+  };
+
+  const setIncomeFlagFalse = (): void => {
+    createCategoryFormStore.setIncomeFlagFalse();
+  };
+
   return (
     <SettingsCategoryViewWrapper>
       <FormModalCategory />
@@ -69,7 +78,7 @@ const SettingsCategoriesView: React.FC<Props> = ({ accountbookId }: Props) => {
         <Label>지출</Label>
         <CategoryWrapper>
           <CategoryItemWrapper>
-            <AddCategoryButton />
+            <AddCategoryButton onClick={setIncomeFlagFalse} />
           </CategoryItemWrapper>
           {ExpenditureCategoryItems}
         </CategoryWrapper>
@@ -78,7 +87,7 @@ const SettingsCategoriesView: React.FC<Props> = ({ accountbookId }: Props) => {
         <Label>수입</Label>
         <CategoryWrapper>
           <CategoryItemWrapper>
-            <AddCategoryButton />
+            <AddCategoryButton onClick={setIncomeFlagTrue} />
           </CategoryItemWrapper>
           {IncomeCategoryItems}
         </CategoryWrapper>

--- a/client/src/pages/settings-categories-page/SettingsCategoriesView.tsx
+++ b/client/src/pages/settings-categories-page/SettingsCategoriesView.tsx
@@ -5,6 +5,7 @@ import AddCategoryButton from '../../components/common/add-category-button/AddCa
 import useStore from '../../hook/use-store/useStore';
 import { observer } from 'mobx-react';
 import FormModalCategory from '../../components/common/modals/form-modal-category/FormModalCreateCategory';
+import FormModalUpdateCategory from '../../components/common/modals/form-modal-category/FormModalUpdateCategory';
 
 const SettingsCategoryViewWrapper = styled.div`
   position: absolute;
@@ -74,6 +75,7 @@ const SettingsCategoriesView: React.FC<Props> = ({ accountbookId }: Props) => {
   return (
     <SettingsCategoryViewWrapper>
       <FormModalCategory />
+      <FormModalUpdateCategory />
       <SettingsItemWrapper>
         <Label>지출</Label>
         <CategoryWrapper>

--- a/client/src/services/account.ts
+++ b/client/src/services/account.ts
@@ -16,6 +16,7 @@ export default {
     return response.data;
   },
   createAccount: async (account: AccountRequest): Promise<Account> => {
-    return await instance.post(accountAPIAddress.createAccount, account);
+    const response = await instance.post(accountAPIAddress.createAccount, account);
+    return response.data;
   },
 };

--- a/client/src/services/category.ts
+++ b/client/src/services/category.ts
@@ -26,9 +26,11 @@ export default {
     return response.data;
   },
   createIncomeCategory: async (incomeCategory: CategoryRequest): Promise<Category> => {
-    return await instance.post(categoryAPIAddress.createIncome, incomeCategory);
+    const response = await instance.post(categoryAPIAddress.createIncome, incomeCategory);
+    return response.data;
   },
   createExpenditureCategory: async (expenditureCategory: CategoryRequest): Promise<Category> => {
-    return await instance.post(categoryAPIAddress.createExpenditure, expenditureCategory);
+    const response = await instance.post(categoryAPIAddress.createExpenditure, expenditureCategory);
+    return response.data;
   },
 };

--- a/client/src/store/CategoryStore.tsx
+++ b/client/src/store/CategoryStore.tsx
@@ -38,7 +38,7 @@ export default class CategoryStore {
     this.changeExpenditureCategories(expenditureCategories);
   };
 
-  createIncomeCategories = async (incomeCategory: CategoryRequest): Promise<void> => {
+  createIncomeCategory = async (incomeCategory: CategoryRequest): Promise<void> => {
     const createdExpenditureCategory = await CategoryService.createIncomeCategory(incomeCategory);
     this.addNewExpenditureCategory(createdExpenditureCategory);
   };
@@ -48,7 +48,7 @@ export default class CategoryStore {
     this.incomeCategories = [...this.incomeCategories, incomeCategory];
   };
 
-  createExpenditureCategories = async (expenditureCategory: CategoryRequest): Promise<void> => {
+  createExpenditureCategory = async (expenditureCategory: CategoryRequest): Promise<void> => {
     const createdExpenditureCategory = await CategoryService.createExpenditureCategory(expenditureCategory);
     this.addNewExpenditureCategory(createdExpenditureCategory);
   };

--- a/client/src/store/CategoryStore.tsx
+++ b/client/src/store/CategoryStore.tsx
@@ -3,7 +3,7 @@ import Category, { CategoryRequest } from '../types/category';
 import RootStore from './RootStore';
 import CategoryService from '../services/category';
 import Options from '../types/dropdownOptions';
-import category from '../services/category';
+
 export default class CategoryStore {
   rootStore;
 
@@ -39,8 +39,8 @@ export default class CategoryStore {
   };
 
   createIncomeCategory = async (incomeCategory: CategoryRequest): Promise<void> => {
-    const createdExpenditureCategory = await CategoryService.createIncomeCategory(incomeCategory);
-    this.addNewExpenditureCategory(createdExpenditureCategory);
+    const createdIncomeCategory = await CategoryService.createIncomeCategory(incomeCategory);
+    this.addNewIncomeCategory(createdIncomeCategory);
   };
 
   @action

--- a/client/src/store/modal-store/CreateCategoryFormStore.tsx
+++ b/client/src/store/modal-store/CreateCategoryFormStore.tsx
@@ -7,6 +7,9 @@ export default class CreateCategoryFormStore {
   @observable
   show = false;
 
+  @observable
+  incomeFlag = true;
+
   constructor(rootStore: RootStore) {
     this.rootStore = rootStore;
 
@@ -21,5 +24,15 @@ export default class CreateCategoryFormStore {
   @action
   setShow = (show: boolean): void => {
     this.show = show;
+  };
+
+  @action
+  setIncomeFlagTrue = (): void => {
+    this.incomeFlag = true;
+  };
+
+  @action
+  setIncomeFlagFalse = (): void => {
+    this.incomeFlag = false;
   };
 }

--- a/client/src/store/modal-store/ModalStore.tsx
+++ b/client/src/store/modal-store/ModalStore.tsx
@@ -4,6 +4,7 @@ import CreateTransactionFormStore from './CreateTransactionFormStore';
 import UpdateTransactionFormStore from './UpdateTransactionFormStore';
 import CreateAccountFormStore from './CreateAccountFormStore';
 import CreateCategoryFormStore from './CreateCategoryFormStore';
+import UpdateAccountFormStore from './UpdateAccountFormStore';
 
 export default class ModalStore {
   rootStore: RootStore;
@@ -12,6 +13,7 @@ export default class ModalStore {
   updateTransactionFormStore: UpdateTransactionFormStore;
   createAccountFormStore: CreateAccountFormStore;
   createCategoryFormStore: CreateCategoryFormStore;
+  updateAccountFormStore: UpdateAccountFormStore;
 
   constructor(rootStore: RootStore) {
     this.formFilterStore = new FormFilterStore(rootStore);
@@ -20,5 +22,6 @@ export default class ModalStore {
     this.updateTransactionFormStore = new UpdateTransactionFormStore(rootStore);
     this.createAccountFormStore = new CreateAccountFormStore(rootStore);
     this.createCategoryFormStore = new CreateCategoryFormStore(rootStore);
+    this.updateAccountFormStore = new UpdateAccountFormStore(rootStore);
   }
 }

--- a/client/src/store/modal-store/ModalStore.tsx
+++ b/client/src/store/modal-store/ModalStore.tsx
@@ -5,6 +5,7 @@ import UpdateTransactionFormStore from './UpdateTransactionFormStore';
 import CreateAccountFormStore from './CreateAccountFormStore';
 import CreateCategoryFormStore from './CreateCategoryFormStore';
 import UpdateAccountFormStore from './UpdateAccountFormStore';
+import UpdateCategoryFormStore from './UpdateCategoryFormStore';
 
 export default class ModalStore {
   rootStore: RootStore;
@@ -14,6 +15,7 @@ export default class ModalStore {
   createAccountFormStore: CreateAccountFormStore;
   createCategoryFormStore: CreateCategoryFormStore;
   updateAccountFormStore: UpdateAccountFormStore;
+  updateCategoryFormStore: UpdateCategoryFormStore;
 
   constructor(rootStore: RootStore) {
     this.formFilterStore = new FormFilterStore(rootStore);
@@ -23,5 +25,6 @@ export default class ModalStore {
     this.createAccountFormStore = new CreateAccountFormStore(rootStore);
     this.createCategoryFormStore = new CreateCategoryFormStore(rootStore);
     this.updateAccountFormStore = new UpdateAccountFormStore(rootStore);
+    this.updateCategoryFormStore = new UpdateCategoryFormStore(rootStore);
   }
 }

--- a/client/src/store/modal-store/UpdateAccountFormStore.tsx
+++ b/client/src/store/modal-store/UpdateAccountFormStore.tsx
@@ -1,0 +1,29 @@
+import { observable, action, makeAutoObservable } from 'mobx';
+import RootStore from '../RootStore';
+
+export default class UpdateAccountFormStore {
+  rootStore: RootStore;
+
+  @observable
+  show = false;
+
+  constructor(rootStore: RootStore) {
+    this.rootStore = rootStore;
+    makeAutoObservable(this);
+  }
+
+  @action
+  toggleShow = (): void => {
+    this.show = !this.show;
+  };
+
+  @action
+  setShowTrue = (): void => {
+    this.show = true;
+  };
+
+  @action
+  setShowFalse = (): void => {
+    this.show = false;
+  };
+}

--- a/client/src/store/modal-store/UpdateCategoryFormStore.tsx
+++ b/client/src/store/modal-store/UpdateCategoryFormStore.tsx
@@ -1,0 +1,29 @@
+import { observable, action, makeAutoObservable } from 'mobx';
+import RootStore from '../RootStore';
+
+export default class UpdateCategoryFormStore {
+  rootStore: RootStore;
+
+  @observable
+  show = false;
+
+  constructor(rootStore: RootStore) {
+    this.rootStore = rootStore;
+    makeAutoObservable(this);
+  }
+
+  @action
+  toggleShow = (): void => {
+    this.show = !this.show;
+  };
+
+  @action
+  setShowTrue = (): void => {
+    this.show = true;
+  };
+
+  @action
+  setShowFalse = (): void => {
+    this.show = false;
+  };
+}

--- a/client/src/types/account.ts
+++ b/client/src/types/account.ts
@@ -6,7 +6,6 @@ export interface Account {
 
 export interface AccountRequest {
   accountbookId: number;
-  id: number;
   name: string;
   color: string;
 }

--- a/client/src/types/category.ts
+++ b/client/src/types/category.ts
@@ -6,7 +6,6 @@ export interface Category {
 
 export interface CategoryRequest {
   accountbookId: number;
-  id: number;
   name: string;
   color: string;
 }

--- a/server/src/api/controllers/account.js
+++ b/server/src/api/controllers/account.js
@@ -14,10 +14,8 @@ const getAccounts = async (ctx) => {
 };
 
 const createAccount = async (ctx) => {
-  // TODO: FE에서 accountbookId를 request body로 넘겨받는 로직 구현 필요
-  const accountbookId = 1;
   const accountData = ctx.request.body;
-  const createdAccount = await accountService.createAccount(accountbookId, accountData);
+  const createdAccount = await accountService.createAccount(accountData);
   ctx.body = createdAccount;
 };
 

--- a/server/src/api/controllers/account.js
+++ b/server/src/api/controllers/account.js
@@ -20,9 +20,9 @@ const createAccount = async (ctx) => {
 };
 
 const updateAccount = async (ctx) => {
-  const { accountbook_id: accountbookId } = ctx.request.params;
+  const { account_id: accountId } = ctx.request.params;
   const accountData = ctx.request.body;
-  const updatedAccount = await accountService.updateAccount(accountbookId, accountData);
+  const updatedAccount = await accountService.updateAccount(accountId, accountData);
   ctx.body = updatedAccount;
 };
 

--- a/server/src/api/controllers/account.js
+++ b/server/src/api/controllers/account.js
@@ -26,8 +26,15 @@ const updateAccount = async (ctx) => {
   ctx.body = updatedAccount;
 };
 
+const deleteAccount = async (ctx) => {
+  const { account_id: accountId } = ctx.request.params;
+  await accountService.deleteAccount(accountId);
+  ctx.status = 204;
+};
+
 module.exports = {
   getAccounts,
   createAccount,
   updateAccount,
+  deleteAccount,
 };

--- a/server/src/api/controllers/account.js
+++ b/server/src/api/controllers/account.js
@@ -19,7 +19,15 @@ const createAccount = async (ctx) => {
   ctx.body = createdAccount;
 };
 
+const updateAccount = async (ctx) => {
+  const { accountbook_id: accountbookId } = ctx.request.params;
+  const accountData = ctx.request.body;
+  const updatedAccount = await accountService.updateAccount(accountbookId, accountData);
+  ctx.body = updatedAccount;
+};
+
 module.exports = {
   getAccounts,
   createAccount,
+  updateAccount,
 };

--- a/server/src/api/controllers/category.js
+++ b/server/src/api/controllers/category.js
@@ -32,9 +32,17 @@ const createExpenditureCategory = async (ctx) => {
   ctx.body = createdExpenditureCategory;
 };
 
+const updateIncomeCategory = async (ctx) => {
+  const { income_category_id: incomeCategoryId } = ctx.request.params;
+  const incomeCategoryData = ctx.request.body;
+  const updatedIncomeCategory = await categoryService.updateIncomeCategory(incomeCategoryId, incomeCategoryData);
+  ctx.body = updatedIncomeCategory;
+};
+
 module.exports = {
   getIncomeCategories,
   getExpenditureCategories,
   createIncomeCategory,
   createExpenditureCategory,
+  updateIncomeCategory,
 };

--- a/server/src/api/controllers/category.js
+++ b/server/src/api/controllers/category.js
@@ -49,6 +49,11 @@ const updateExpenditureCategory = async (ctx) => {
   ctx.body = updatedExpenditureCategory;
 };
 
+const deleteIncomeCategory = async (ctx) => {
+  const { income_category_id: incomeCategoryId } = ctx.request.params;
+  await categoryService.deleteIncomeCategory(incomeCategoryId);
+};
+
 module.exports = {
   getIncomeCategories,
   getExpenditureCategories,
@@ -56,4 +61,5 @@ module.exports = {
   createExpenditureCategory,
   updateIncomeCategory,
   updateExpenditureCategory,
+  deleteIncomeCategory,
 };

--- a/server/src/api/controllers/category.js
+++ b/server/src/api/controllers/category.js
@@ -55,6 +55,12 @@ const deleteIncomeCategory = async (ctx) => {
   ctx.status = 204;
 };
 
+const deleteExpenditureCategory = async (ctx) => {
+  const { expenditure_category_id: expenditureCategoryId } = ctx.request.params;
+  await categoryService.deleteExpenditureCategory(expenditureCategoryId);
+  ctx.status = 204;
+};
+
 module.exports = {
   getIncomeCategories,
   getExpenditureCategories,
@@ -63,4 +69,5 @@ module.exports = {
   updateIncomeCategory,
   updateExpenditureCategory,
   deleteIncomeCategory,
+  deleteExpenditureCategory,
 };

--- a/server/src/api/controllers/category.js
+++ b/server/src/api/controllers/category.js
@@ -52,6 +52,7 @@ const updateExpenditureCategory = async (ctx) => {
 const deleteIncomeCategory = async (ctx) => {
   const { income_category_id: incomeCategoryId } = ctx.request.params;
   await categoryService.deleteIncomeCategory(incomeCategoryId);
+  ctx.status = 204;
 };
 
 module.exports = {

--- a/server/src/api/controllers/category.js
+++ b/server/src/api/controllers/category.js
@@ -21,21 +21,14 @@ const getExpenditureCategories = async (ctx) => {
 };
 
 const createIncomeCategory = async (ctx) => {
-  // TODO: FE에서 accountbookId를 request body로 넘겨받는 로직 구현 필요
-  const accountbookId = 1;
   const incomeCategoryData = ctx.request.body;
-  const createdIncomeCategory = await categoryService.createIncomeCategory(accountbookId, incomeCategoryData);
+  const createdIncomeCategory = await categoryService.createIncomeCategory(incomeCategoryData);
   ctx.body = createdIncomeCategory;
 };
 
 const createExpenditureCategory = async (ctx) => {
-  // TODO: FE에서 accountbookId를 request body로 넘겨받는 로직 구현 필요
-  const accountbookId = 1;
   const expenditureCategoryData = ctx.request.body;
-  const createdExpenditureCategory = await categoryService.createExpenditureCategory(
-    accountbookId,
-    expenditureCategoryData,
-  );
+  const createdExpenditureCategory = await categoryService.createExpenditureCategory(expenditureCategoryData);
   ctx.body = createdExpenditureCategory;
 };
 

--- a/server/src/api/controllers/category.js
+++ b/server/src/api/controllers/category.js
@@ -39,10 +39,21 @@ const updateIncomeCategory = async (ctx) => {
   ctx.body = updatedIncomeCategory;
 };
 
+const updateExpenditureCategory = async (ctx) => {
+  const { expenditure_category_id: expenditureCategoryId } = ctx.request.params;
+  const expenditureCategoryData = ctx.request.body;
+  const updatedExpenditureCategory = await categoryService.updateExpenditureCategory(
+    expenditureCategoryId,
+    expenditureCategoryData,
+  );
+  ctx.body = updatedExpenditureCategory;
+};
+
 module.exports = {
   getIncomeCategories,
   getExpenditureCategories,
   createIncomeCategory,
   createExpenditureCategory,
   updateIncomeCategory,
+  updateExpenditureCategory,
 };

--- a/server/src/api/routes/account.js
+++ b/server/src/api/routes/account.js
@@ -4,6 +4,6 @@ const accountController = require('@controllers/account');
 const router = new Router();
 router.get('/', accountController.getAccounts);
 router.post('/', accountController.createAccount);
-router.patch('/:accounts_id', accountController.updateAccount);
+router.patch('/:account_id', accountController.updateAccount);
 
 module.exports = router;

--- a/server/src/api/routes/account.js
+++ b/server/src/api/routes/account.js
@@ -5,5 +5,6 @@ const router = new Router();
 router.get('/', accountController.getAccounts);
 router.post('/', accountController.createAccount);
 router.patch('/:account_id', accountController.updateAccount);
+router.delete('/:account_id', accountController.deleteAccount);
 
 module.exports = router;

--- a/server/src/api/routes/account.js
+++ b/server/src/api/routes/account.js
@@ -4,5 +4,6 @@ const accountController = require('@controllers/account');
 const router = new Router();
 router.get('/', accountController.getAccounts);
 router.post('/', accountController.createAccount);
+router.patch('/', accountController.updateAccount);
 
 module.exports = router;

--- a/server/src/api/routes/account.js
+++ b/server/src/api/routes/account.js
@@ -4,6 +4,6 @@ const accountController = require('@controllers/account');
 const router = new Router();
 router.get('/', accountController.getAccounts);
 router.post('/', accountController.createAccount);
-router.patch('/', accountController.updateAccount);
+router.patch('/:accounts_id', accountController.updateAccount);
 
 module.exports = router;

--- a/server/src/api/routes/category.js
+++ b/server/src/api/routes/category.js
@@ -8,5 +8,6 @@ router.get('/expenditure', categoryController.getExpenditureCategories);
 router.post('/income', categoryController.createIncomeCategory);
 router.post('/expenditure', categoryController.createExpenditureCategory);
 router.patch('/income/:income_category_id', categoryController.updateIncomeCategory);
+router.patch('/expenditure/:expenditure_category_id', categoryController.updateExpenditureCategory);
 
 module.exports = router;

--- a/server/src/api/routes/category.js
+++ b/server/src/api/routes/category.js
@@ -10,5 +10,6 @@ router.post('/expenditure', categoryController.createExpenditureCategory);
 router.patch('/income/:income_category_id', categoryController.updateIncomeCategory);
 router.patch('/expenditure/:expenditure_category_id', categoryController.updateExpenditureCategory);
 router.delete('/income/:income_category_id', categoryController.deleteIncomeCategory);
+router.delete('/expenditure/:expenditure_category_id', categoryController.deleteExpenditureCategory);
 
 module.exports = router;

--- a/server/src/api/routes/category.js
+++ b/server/src/api/routes/category.js
@@ -7,5 +7,6 @@ router.get('/income', categoryController.getIncomeCategories);
 router.get('/expenditure', categoryController.getExpenditureCategories);
 router.post('/income', categoryController.createIncomeCategory);
 router.post('/expenditure', categoryController.createExpenditureCategory);
+router.patch('/income/:income_category_id', categoryController.updateIncomeCategory);
 
 module.exports = router;

--- a/server/src/api/routes/category.js
+++ b/server/src/api/routes/category.js
@@ -9,5 +9,6 @@ router.post('/income', categoryController.createIncomeCategory);
 router.post('/expenditure', categoryController.createExpenditureCategory);
 router.patch('/income/:income_category_id', categoryController.updateIncomeCategory);
 router.patch('/expenditure/:expenditure_category_id', categoryController.updateExpenditureCategory);
+router.delete('/income/:income_category_id', categoryController.deleteIncomeCategory);
 
 module.exports = router;

--- a/server/src/services/account.js
+++ b/server/src/services/account.js
@@ -28,8 +28,23 @@ const createAccount = async ({ accountbookId, name, color }) => {
   return createdAccount;
 };
 
+const updateAccount = async (accountId, { name, color }) => {
+  await db.account.update(
+    {
+      name,
+      color,
+    },
+    {
+      where: { id: accountId },
+    },
+  );
+  const updatedAccount = await findAccountById(accountId);
+  return updatedAccount;
+};
+
 module.exports = {
   getAccountsByAccountbookId,
   createAccount,
   findAccountById,
+  updateAccount,
 };

--- a/server/src/services/account.js
+++ b/server/src/services/account.js
@@ -9,8 +9,8 @@ const getAccountsByAccountbookId = async (id) => {
   return accounts;
 };
 
-const createAccount = async (id, { name, color }) => {
-  const accountbook = await getAccountbookById(id);
+const createAccount = async ({ accountbookId, name, color }) => {
+  const accountbook = await getAccountbookById(accountbookId);
 
   const createdAccount = await accountbook.createAccount({
     name,

--- a/server/src/services/account.js
+++ b/server/src/services/account.js
@@ -42,9 +42,14 @@ const updateAccount = async (accountId, { name, color }) => {
   return updatedAccount;
 };
 
+const deleteAccount = async (id) => {
+  await db.account.destroy({ where: { id } });
+};
+
 module.exports = {
   getAccountsByAccountbookId,
   createAccount,
   findAccountById,
   updateAccount,
+  deleteAccount,
 };

--- a/server/src/services/account.js
+++ b/server/src/services/account.js
@@ -9,18 +9,27 @@ const getAccountsByAccountbookId = async (id) => {
   return accounts;
 };
 
+const findAccountById = async (id) => {
+  const account = await db.account.findOne({
+    attributes: ['id', 'name', 'color'],
+    where: {
+      id,
+    },
+  });
+  return account;
+};
+
 const createAccount = async ({ accountbookId, name, color }) => {
   const accountbook = await getAccountbookById(accountbookId);
-
   const createdAccount = await accountbook.createAccount({
     name,
     color,
   });
-
   return createdAccount;
 };
 
 module.exports = {
   getAccountsByAccountbookId,
   createAccount,
+  findAccountById,
 };

--- a/server/src/services/category.js
+++ b/server/src/services/category.js
@@ -87,6 +87,10 @@ const deleteIncomeCategory = async (id) => {
   await db.incomeCategory.destroy({ where: { id } });
 };
 
+const deleteExpenditureCategory = async (id) => {
+  await db.expenditureCategory.destroy({ where: { id } });
+};
+
 module.exports = {
   getIncomeCategoriesByAccountbookId,
   getExpenditureCategoriesByAccountbookId,
@@ -95,4 +99,5 @@ module.exports = {
   updateIncomeCategory,
   updateExpenditureCategory,
   deleteIncomeCategory,
+  deleteExpenditureCategory,
 };

--- a/server/src/services/category.js
+++ b/server/src/services/category.js
@@ -45,9 +45,24 @@ const createExpenditureCategory = async ({ accountbookId, name, color }) => {
   return createdExpenditureCategory;
 };
 
+const updateIncomeCategory = async (incomeCategoryId, { name, color }) => {
+  await db.incomeCategory.update(
+    {
+      name,
+      color,
+    },
+    {
+      where: { id: incomeCategoryId },
+    },
+  );
+  const updatedIncomeCategory = await findIncomeCategoryById(incomeCategoryId);
+  return updatedIncomeCategory;
+};
+
 module.exports = {
   getIncomeCategoriesByAccountbookId,
   getExpenditureCategoriesByAccountbookId,
   createIncomeCategory,
   createExpenditureCategory,
+  updateIncomeCategory,
 };

--- a/server/src/services/category.js
+++ b/server/src/services/category.js
@@ -83,6 +83,10 @@ const updateExpenditureCategory = async (expenditureCategoryId, { name, color })
   return updatedExpenditureCategory;
 };
 
+const deleteIncomeCategory = async (id) => {
+  await db.incomeCategory.destroy({ where: { id } });
+};
+
 module.exports = {
   getIncomeCategoriesByAccountbookId,
   getExpenditureCategoriesByAccountbookId,
@@ -90,4 +94,5 @@ module.exports = {
   createExpenditureCategory,
   updateIncomeCategory,
   updateExpenditureCategory,
+  deleteIncomeCategory,
 };

--- a/server/src/services/category.js
+++ b/server/src/services/category.js
@@ -29,7 +29,7 @@ const createIncomeCategory = async ({ accountbookId, name, color }) => {
 
 const createExpenditureCategory = async ({ accountbookId, name, color }) => {
   const accountbook = await getAccountbookById(accountbookId);
-  const createdExpenditureCategory = await accountbook.createdExpenditureCategory({
+  const createdExpenditureCategory = await accountbook.createExpenditureCategory({
     name,
     color,
   });

--- a/server/src/services/category.js
+++ b/server/src/services/category.js
@@ -27,7 +27,7 @@ const findIncomeCategoryById = async (id) => {
   return incomeCategory;
 };
 
-const findExpenditureeCategoryById = async (id) => {
+const findExpenditureCategoryById = async (id) => {
   const expenditureCategory = await db.expenditureCategory.findOne({
     attributes: ['id', 'name', 'color'],
     where: {
@@ -69,10 +69,25 @@ const updateIncomeCategory = async (incomeCategoryId, { name, color }) => {
   return updatedIncomeCategory;
 };
 
+const updateExpenditureCategory = async (expenditureCategoryId, { name, color }) => {
+  await db.expenditureCategory.update(
+    {
+      name,
+      color,
+    },
+    {
+      where: { id: expenditureCategoryId },
+    },
+  );
+  const updatedExpenditureCategory = await findExpenditureCategoryById(expenditureCategoryId);
+  return updatedExpenditureCategory;
+};
+
 module.exports = {
   getIncomeCategoriesByAccountbookId,
   getExpenditureCategoriesByAccountbookId,
   createIncomeCategory,
   createExpenditureCategory,
   updateIncomeCategory,
+  updateExpenditureCategory,
 };

--- a/server/src/services/category.js
+++ b/server/src/services/category.js
@@ -1,3 +1,4 @@
+const db = require('@models');
 const { getAccountbookById } = require('@services/accountbook');
 
 const getIncomeCategoriesByAccountbookId = async (id) => {
@@ -13,8 +14,17 @@ const getExpenditureCategoriesByAccountbookId = async (id) => {
   const expenditureCategories = await accountBook.getExpenditureCategories({
     attributes: ['id', 'name', 'color'],
   });
-
   return expenditureCategories;
+};
+
+const findIncomeCategoryById = async (id) => {
+  const incomeCategory = await db.incomeCategory.findOne({
+    attributes: ['id', 'name', 'color'],
+    where: {
+      id,
+    },
+  });
+  return incomeCategory;
 };
 
 const createIncomeCategory = async ({ accountbookId, name, color }) => {
@@ -23,7 +33,6 @@ const createIncomeCategory = async ({ accountbookId, name, color }) => {
     name,
     color,
   });
-
   return createdIncomeCategory;
 };
 
@@ -33,7 +42,6 @@ const createExpenditureCategory = async ({ accountbookId, name, color }) => {
     name,
     color,
   });
-
   return createdExpenditureCategory;
 };
 

--- a/server/src/services/category.js
+++ b/server/src/services/category.js
@@ -17,8 +17,8 @@ const getExpenditureCategoriesByAccountbookId = async (id) => {
   return expenditureCategories;
 };
 
-const createIncomeCategory = async (id, { name, color }) => {
-  const accountbook = await getAccountbookById(id);
+const createIncomeCategory = async ({ accountbookId, name, color }) => {
+  const accountbook = await getAccountbookById(accountbookId);
   const createdIncomeCategory = await accountbook.createIncomeCategory({
     name,
     color,
@@ -27,8 +27,8 @@ const createIncomeCategory = async (id, { name, color }) => {
   return createdIncomeCategory;
 };
 
-const createExpenditureCategory = async (id, { name, color }) => {
-  const accountbook = await getAccountbookById(id);
+const createExpenditureCategory = async ({ accountbookId, name, color }) => {
+  const accountbook = await getAccountbookById(accountbookId);
   const createdExpenditureCategory = await accountbook.createdExpenditureCategory({
     name,
     color,

--- a/server/src/services/category.js
+++ b/server/src/services/category.js
@@ -27,6 +27,16 @@ const findIncomeCategoryById = async (id) => {
   return incomeCategory;
 };
 
+const findExpenditureeCategoryById = async (id) => {
+  const expenditureCategory = await db.expenditureCategory.findOne({
+    attributes: ['id', 'name', 'color'],
+    where: {
+      id,
+    },
+  });
+  return expenditureCategory;
+};
+
 const createIncomeCategory = async ({ accountbookId, name, color }) => {
   const accountbook = await getAccountbookById(accountbookId);
   const createdIncomeCategory = await accountbook.createIncomeCategory({


### PR DESCRIPTION
## 관련 이슈
close #198 [가계부 관리 페이지] 결제수단 수정 API 
close #199 [가계부 관리 페이지] 지출/수입 카테고리 수정 API 
#200 [가계부 관리 페이지] 결제수단 수정/삭제 모달창 구현 
#201 [가계부 관리 페이지] 지출/수입 카테고리 수정/삭제 모달창 구현 
close #209 [가계부 관리 페이지] 결제수단 삭제 API 
close #210 [가계부 관리 페이지] 지출/수입 카테고리 삭제 API 
<br>

## 구현 세부사항
- 카테고리 관리 페이지
    - 지출/수입 카테고리 생성 기능 FE, BE 연동 완료
    - BE
        - 특정한 수입/지출 카테고리를 수정하는 API 구현 및 관련 BE 로직 추가
        - 특정한 수입/지출 카테고리를 삭제하는 API 구현 및 관련 BE 로직 추가
    - FE
        - 카테고리 수정/삭제 모달창 구현

- 결제수단 관리 페이지
    - 결제수단 생성 기능 FE, BE 연동 완료
    - BE
        - 특정한 결제수단을 수정하는 API 구현 및 관련 BE 로직 추가
        - 특정한 결제수단을 삭제하는 API 구현 및 관련 BE 로직 추가
    - FE
        - 결제수단 수정/삭제 모달창 구현
<br>

## 카테고리 수정/삭제 모달창
<img width="1444" alt="스크린샷 2020-12-09 오전 2 18 09" src="https://user-images.githubusercontent.com/42263086/101518077-ca93f700-39c4-11eb-88a6-21fbb0ee75d6.png">
<br>

## 결제수단 수정/삭제 모달창
<img width="1445" alt="스크린샷 2020-12-09 오전 2 18 46" src="https://user-images.githubusercontent.com/42263086/101518148-e0092100-39c4-11eb-9468-c5a28842b064.png">
<br>


## 기타사항
- BE에서 카테고리 수정/삭제 및 결제수단 수정/삭제 API는 테스트를 마쳤으나 BE, FE 연동 구현 필요
- 카테고리 및 결제수단 컴포넌트 클릭 시 해당하는 컴포넌트가 가진 데이터들이 모달창에 들어가는 로직 구현 필요
<br>

@boostcamp-2020/accountbook_mentor 


