### PR TITLE
PieGraph 페이지 생성

### DIFF
--- a/client/src/components/common/category/Category.tsx
+++ b/client/src/components/common/category/Category.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import { getTextColor } from '../../../utils/color';
 import useStore from '../../../hook/use-store/useStore';
 
-const CategoryWrapper = styled.div<{ bgColor: string; textColor: string; shadow?: boolean }>`
+export const CategoryWrapper = styled.div<{ bgColor: string; textColor: string; shadow?: boolean }>`
   width: 100%;
   max-width: 115px;
   height: 100%;
@@ -24,7 +24,7 @@ const CategoryWrapper = styled.div<{ bgColor: string; textColor: string; shadow?
   }
 `;
 
-interface CategoryProps {
+export interface CategoryProps {
   text: string | undefined;
   bgColor: string;
   shadow?: boolean;

--- a/client/src/components/common/category/CategoryNoDependency.tsx
+++ b/client/src/components/common/category/CategoryNoDependency.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import styled from 'styled-components';
+import { CategoryWrapper, CategoryProps } from './Category';
+import { getTextColor } from '../../../utils/color';
+
+const TextSmall = styled.p`
+  font-size: 0.9em;
+  padding: 0;
+  margin: 0;
+`;
+
+const CategoryNoDependency: React.FC<CategoryProps> = ({ text, bgColor, shadow, onClick }: CategoryProps) => {
+  const textColor = getTextColor(bgColor);
+  return (
+    <CategoryWrapper bgColor={bgColor} textColor={textColor} shadow={shadow} onClick={onClick}>
+      <TextSmall>{text}</TextSmall>
+    </CategoryWrapper>
+  );
+};
+
+export default CategoryNoDependency;

--- a/client/src/components/common/inputs/input-with-next-button/InputWithNextButton.stories.tsx
+++ b/client/src/components/common/inputs/input-with-next-button/InputWithNextButton.stories.tsx
@@ -3,6 +3,7 @@ import InputWithNextButton from './InputWithNextButton';
 
 export default {
   title: '통계페이지 인풋 박스',
+  component: InputWithNextButton,
 };
 
 export const InputWithNextButtonDefault: React.FC = () => {

--- a/client/src/components/common/inputs/input-with-next-button/InputWithNextButton.tsx
+++ b/client/src/components/common/inputs/input-with-next-button/InputWithNextButton.tsx
@@ -1,7 +1,58 @@
 import React from 'react';
+import styled from 'styled-components';
+import InputText from '../input-text/InputText';
+import PrevButton from '../../back-button/PreviousButton';
+import NextButton from '../../next-button/NextButton';
 
-const InputWithNextButton: React.FC = () => {
-  return <div>안녕하세요</div>;
+const InputWrapper = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+`;
+
+const SvgWrapper = styled.div`
+  width: 3em;
+  cursor: pointer;
+`;
+
+const InputTextWrapper = styled.div`
+  width: 100%;
+  box-sizing: border-box;
+  margin: 0px 5px;
+`;
+
+const SmallInput = styled.input`
+  width: 100%;
+  box-sizing: border-box;
+  margin: 0px;
+  padding: 0px;
+  height: 3em;
+  text-align: center;
+  background-color: white;
+  border: 1px solid lightgray;
+  border-radius: 5px;
+`;
+
+interface IInputWithNextButton {
+  clickPrev?: () => void;
+  clickNext?: () => void;
+  value?: string;
+}
+
+const InputWithNextButton: React.FC<IInputWithNextButton> = ({ clickPrev, clickNext, value }: IInputWithNextButton) => {
+  return (
+    <InputWrapper>
+      <SvgWrapper onClick={clickPrev}>
+        <PrevButton />
+      </SvgWrapper>
+      <InputTextWrapper>
+        <SmallInput disabled value={value} />
+      </InputTextWrapper>
+      <SvgWrapper onClick={clickNext}>
+        <NextButton />
+      </SvgWrapper>
+    </InputWrapper>
+  );
 };
 
 export default InputWithNextButton;

--- a/client/src/components/common/inputs/select/Select.tsx
+++ b/client/src/components/common/inputs/select/Select.tsx
@@ -24,7 +24,7 @@ interface SelectWrapperProps {
 
 const SelectWrapper = styled.div<SelectWrapperProps>`
   width: 100%;
-  padding: 10px 5px;
+  padding: 5px 5px;
   font-size: 1rem;
   border-radius: 5px;
   border: 1px solid lightgray;

--- a/client/src/components/common/modals/modals.stories.tsx
+++ b/client/src/components/common/modals/modals.stories.tsx
@@ -71,23 +71,3 @@ export const FormModalFilterDefault: React.FC = () => {
     </>
   );
 };
-
-export const FormModalTransactionDefault: React.FC = () => {
-  return <FormModalTransaction />;
-};
-
-export const FormModalAccountDefault: React.FC = () => {
-  return <FormModalAccount />;
-};
-
-export const FormModalCategoryDefault: React.FC = () => {
-  return <FormModalCategory />;
-};
-
-export const FormModalUpdateAccountDefault: React.FC = () => {
-  return <FormModalUpdateAccount />;
-};
-
-export const FormModalUpdateCategoryDefault: React.FC = () => {
-  return <FormModalUpdateCategory />;
-};

--- a/client/src/components/graph/box-graph/BoxGraph.tsx
+++ b/client/src/components/graph/box-graph/BoxGraph.tsx
@@ -32,8 +32,28 @@ const BoxAnimation = (ratio: number) => keyframes`
   width:0%;
   height:100%;
 }
+30%{
+  width:${ratio + '%'};
+  height:100%;
+}
+35%{
+  width:${ratio + 1 + '%'};
+  height:100%;
+}
+55%{
+  width:${ratio + 0 + '%'};
+  height:100%;
+}
+75%{
+  width:${ratio + 0.25 + '%'};
+  height:100%;
+}
+90%{
+  width:${ratio + '%'};
+  height:100%;
+}
 100%{
-  width:${ratio};
+  width:${ratio + '%'};
   height:100%;
 }
 `;
@@ -42,7 +62,7 @@ const Box = styled.rect<Box>`
   width: ${(props) => props.ratio + '%'};
   height: 100%;
   fill: ${(props) => props.color};
-  animation: ${(props) => BoxAnimation(props.ratio)} 1s ease;
+  animation: ${(props) => BoxAnimation(props.ratio)} 1.5s ease;
 `;
 
 const BoxGraphValue = styled.p`

--- a/client/src/components/graph/box-graph/BoxGraph.tsx
+++ b/client/src/components/graph/box-graph/BoxGraph.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import BoxChartValue from '../../../types/boxChartValue';
 import styled, { keyframes } from 'styled-components';
-
+import { numberWithCommas } from '../../../utils/number';
 const BoxGraphWrapper = styled.div`
   width: 100%;
   display: flex;
@@ -10,16 +10,19 @@ const BoxGraphWrapper = styled.div`
 `;
 
 const BoxGraphTitle = styled.p`
-  margin-right: 3em;
+  width: 10%;
+  margin-right: 1em;
 `;
 
 const BoxGraphRatio = styled.p`
+  width: 10%;
   margin-right: 3em;
 `;
 
 const BoxGraphMain = styled.svg`
   flex: 1;
   height: 2em;
+  margin-right: 1em;
 `;
 
 interface Box {
@@ -76,11 +79,11 @@ const BoxGraph: React.FC<BoxChartValue> = ({ title, color, ratio, value }: BoxCh
   return (
     <BoxGraphWrapper>
       <BoxGraphTitle>{title}</BoxGraphTitle>
-      <BoxGraphRatio>{ratio}%</BoxGraphRatio>
+      <BoxGraphRatio>{Math.round(ratio * 100) / 100}%</BoxGraphRatio>
       <BoxGraphMain>
         <Box x="0" y="0" width={ratio} height={'100%'} color={color} ratio={ratio} />
       </BoxGraphMain>
-      <BoxGraphValue>{value}원</BoxGraphValue>
+      <BoxGraphValue>{numberWithCommas(value)}원</BoxGraphValue>
     </BoxGraphWrapper>
   );
 };

--- a/client/src/components/graph/line-chart/LineChart.tsx
+++ b/client/src/components/graph/line-chart/LineChart.tsx
@@ -44,7 +44,7 @@ const Path = styled.path<IPath>`
   stroke: dodgerblue;
   stroke-width: 0;
   stroke-dasharray: ${(props) => props.length};
-  animation: ${(props) => pathAnimation(props.length)} 2s ease 1.7s both;
+  animation: ${(props) => pathAnimation(props.length)} 1.5s ease 1.7s both;
 `;
 
 const LineChart: React.FC<IProps> = ({ transactions }: IProps) => {

--- a/client/src/components/graph/line-chart/LineChart.tsx
+++ b/client/src/components/graph/line-chart/LineChart.tsx
@@ -44,7 +44,7 @@ const Path = styled.path<IPath>`
   stroke: dodgerblue;
   stroke-width: 0;
   stroke-dasharray: ${(props) => props.length};
-  animation: ${(props) => pathAnimation(props.length)} 1.5s ease 1.7s both;
+  animation: ${(props) => pathAnimation(props.length)} 1.3s ease 1.7s both;
 `;
 
 const LineChart: React.FC<IProps> = ({ transactions }: IProps) => {

--- a/client/src/components/graph/line-chart/LineChart.tsx
+++ b/client/src/components/graph/line-chart/LineChart.tsx
@@ -44,7 +44,7 @@ const Path = styled.path<IPath>`
   stroke: dodgerblue;
   stroke-width: 0;
   stroke-dasharray: ${(props) => props.length};
-  animation: ${(props) => pathAnimation(props.length)} 1.3s ease 1.7s both;
+  animation: ${(props) => pathAnimation(props.length)} 1.5s ease 1.7s both;
 `;
 
 const LineChart: React.FC<IProps> = ({ transactions }: IProps) => {

--- a/client/src/components/graph/pie/Circle.tsx
+++ b/client/src/components/graph/pie/Circle.tsx
@@ -53,6 +53,9 @@ const CircleSVG = (props: CircleSVGProps): JSX.Element => {
   const CircleDiameter = Math.PI * radius * 2;
 
   const getLengthByRatio = (ratio: number): number => {
+    if (ratio < 0) {
+      return 0;
+    }
     return (CircleDiameter / 100) * ratio;
   };
 

--- a/client/src/components/graph/pie/PieGraph.tsx
+++ b/client/src/components/graph/pie/PieGraph.tsx
@@ -4,10 +4,10 @@ import styled, { keyframes } from 'styled-components';
 
 const SVGAnimation = () => keyframes`
 0%{
-  transform:translateY(5%);
+  transform:translateY(3%);
 }
 100%{
-  transform:translateY(-5%);
+  transform:translateY(-3%);
 }
 `;
 

--- a/client/src/components/graph/pie/PieGraph.tsx
+++ b/client/src/components/graph/pie/PieGraph.tsx
@@ -12,7 +12,6 @@ const SVGAnimation = () => keyframes`
 `;
 
 const SVG = styled.svg`
-  transform: rotate(-90deg);
   animation: ${() => SVGAnimation()} 2s alternate infinite;
 `;
 

--- a/client/src/components/graph/pie/PieGraph.tsx
+++ b/client/src/components/graph/pie/PieGraph.tsx
@@ -1,9 +1,19 @@
 import React, { useMemo } from 'react';
 import CircleSVG from './Circle';
-import styled from 'styled-components';
+import styled, { keyframes } from 'styled-components';
+
+const SVGAnimation = () => keyframes`
+0%{
+  transform:translateY(5%);
+}
+100%{
+  transform:translateY(-5%);
+}
+`;
 
 const SVG = styled.svg`
   transform: rotate(-90deg);
+  animation: ${() => SVGAnimation()} 2s alternate infinite;
 `;
 
 const SVGWrapper = styled.div`

--- a/client/src/constants/color.ts
+++ b/client/src/constants/color.ts
@@ -10,6 +10,7 @@ export const MODAL_WHITE = '#ECECEC';
 export const DODGER_BLUE = '#1E90FF';
 export const LIGHT_GREEN = '#11CD6E';
 export const BLACK = '#000000';
+export const NAVER_GREEN = '#2EA043';
 
 const color = {
   BLUE,
@@ -24,6 +25,7 @@ const color = {
   DODGER_BLUE,
   LIGHT_GREEN,
   BLACK,
+  NAVER_GREEN,
 };
 
 export default color;

--- a/client/src/constants/pieGraphPage.ts
+++ b/client/src/constants/pieGraphPage.ts
@@ -1,9 +1,9 @@
 export const text = {
-  totalIncome: '총 수입',
-  totalExpenditure: '총 지출',
-  showIncome: '수입 통계 보기',
-  showExpenditure: '지출 통계 보기',
-  dateInputPlaceholder: '날짜를 선택해주세요',
+  TOTAL_INCOME: '총 수입',
+  TOTAL_EXPENDITURE: '총 지출',
+  SHOW_INCOME: '수입 통계 보기',
+  SHOW_EXPENDITURE: '지출 통계 보기',
+  DATE_INPUT_PLACEHOLDER: '날짜를 선택해주세요',
 };
 
 export const color = {

--- a/client/src/constants/pieGraphPage.ts
+++ b/client/src/constants/pieGraphPage.ts
@@ -1,0 +1,11 @@
+export const text = {
+  totalIncome: '총 수입',
+  totalExpenditure: '총 지출',
+  showIncome: '수입 통계 보기',
+  showExpenditure: '지출 통계 보기',
+  dateInputPlaceholder: '날짜를 선택해주세요',
+};
+
+export const color = {
+  naverGreen: '#2EA043',
+};

--- a/client/src/pages/statistics-page/PieGraphPage.tsx
+++ b/client/src/pages/statistics-page/PieGraphPage.tsx
@@ -1,7 +1,87 @@
-import React from 'react';
+import React, { useEffect } from 'react';
+import styled from 'styled-components';
+import InputWithNextButton from '../../components/common/inputs/input-with-next-button/InputWithNextButton';
+import SingleInputDropDown from '../../components/common/inputs/single-input-dropdown/SingleInputDropdown';
+import useStore from '../../hook/use-store/useStore';
+import { observer } from 'mobx-react';
+import useGetParam from '../../hook/use-get-param/useGetParam';
+import PieGraph from '../../components/graph/pie/PieGraph';
+import NotFoundTransaction from '../../components/common/not-found-transaction/NotFoundTransaction';
+
+const PieGraphPageWrapper = styled.div`
+  margin: 0 auto;
+  width: 70%;
+`;
+const PieHeaderFilter = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+`;
+const DropdownWrapper = styled.div`
+  flex: 1;
+  margin-right: 3em;
+`;
+
+const InputWrapper = styled.div`
+  flex: 1;
+  z-index: 5;
+`;
+
+const PieGraphWrapper = styled.div`
+  margin: 0 auto;
+  margin-top: -5%;
+  width: 70%;
+`;
 
 const PieGraphPage: React.FC = () => {
-  return <div>안녕 파이그래프</div>;
+  const { rootStore } = useStore();
+  console.log('re rendered');
+  const id = useGetParam();
+  const pieGraphStore = rootStore.pieGraphPageStore;
+  console.log(pieGraphStore.transactions);
+  console.log(pieGraphStore.pieChartValue);
+  console.log(pieGraphStore.boxChartValue);
+  useEffect(() => {
+    pieGraphStore.loadTransactions(id);
+  }, []);
+  const selectDateChanged = (string): void => {
+    pieGraphStore.changeSelectedDate(string, id);
+  };
+  const clickPrevButton = (): void => {
+    pieGraphStore.moveToPrev(id);
+  };
+  const clickNextButton = (): void => {
+    pieGraphStore.moveToNext(id);
+  };
+  return (
+    <PieGraphPageWrapper>
+      <PieHeaderFilter>
+        <DropdownWrapper>
+          <SingleInputDropDown
+            items={pieGraphStore.dateOptions}
+            placeholder={'날짜를 선택해주세요'}
+            defaultSelectValue={pieGraphStore.selectedDate}
+            onChange={selectDateChanged}
+          />
+        </DropdownWrapper>
+        <InputWrapper>
+          <InputWithNextButton
+            clickPrev={clickPrevButton}
+            clickNext={clickNextButton}
+            value={pieGraphStore.filteredDate}
+          />
+        </InputWrapper>
+      </PieHeaderFilter>
+      {pieGraphStore.transactions.length === 0 ? (
+        <NotFoundTransaction />
+      ) : (
+        <PieGraphWrapper>
+          <PieGraph transactionData={pieGraphStore.pieChartValue} />
+        </PieGraphWrapper>
+      )}
+    </PieGraphPageWrapper>
+  );
 };
 
-export default PieGraphPage;
+export default observer(PieGraphPage);

--- a/client/src/pages/statistics-page/PieGraphPage.tsx
+++ b/client/src/pages/statistics-page/PieGraphPage.tsx
@@ -9,6 +9,9 @@ import PieGraph from '../../components/graph/pie/PieGraph';
 import NotFoundTransaction from '../../components/common/not-found-transaction/NotFoundTransaction';
 import { numberWithCommas } from '../../utils/number';
 import BoxGraph from '../../components/graph/box-graph/BoxGraph';
+import CategoryNoDependency from '../../components/common/category/CategoryNoDependency';
+import { text, color } from '../../constants/pieGraphPage';
+
 const PieGraphPageWrapper = styled.div`
   margin: 0 auto;
   width: 70%;
@@ -54,6 +57,12 @@ const BarChartList = styled.ul`
   padding: 0;
 `;
 
+const IncomeExpenditureSwitch = styled.div`
+  position: fixed;
+  right: 5%;
+  bottom: 5%;
+`;
+
 const PieGraphPage: React.FC = () => {
   const { rootStore } = useStore();
   console.log('re rendered');
@@ -74,13 +83,16 @@ const PieGraphPage: React.FC = () => {
   const clickNextButton = (): void => {
     pieGraphStore.moveToNext(id);
   };
+  const switchIncomeExpenditure = (): void => {
+    pieGraphStore.switchIncomeMode();
+  };
   return (
     <PieGraphPageWrapper>
       <PieHeaderFilter>
         <DropdownWrapper>
           <SingleInputDropDown
             items={pieGraphStore.dateOptions}
-            placeholder={'날짜를 선택해주세요'}
+            placeholder={text.dateInputPlaceholder}
             defaultSelectValue={pieGraphStore.selectedDate}
             onChange={selectDateChanged}
           />
@@ -102,7 +114,7 @@ const PieGraphPage: React.FC = () => {
           </PieGraphWrapper>
           <BarChartWrapper>
             <BarChartHeaderWrapper>
-              <BarChartHeader>{pieGraphStore.incomeMode ? '총 지출' : '총 수입'}</BarChartHeader>
+              <BarChartHeader>{pieGraphStore.incomeMode ? text.totalExpenditure : text.totalIncome}</BarChartHeader>
               <BarChartHeader>
                 {pieGraphStore.incomeMode
                   ? '-' + numberWithCommas(pieGraphStore.totalValue)
@@ -114,6 +126,13 @@ const PieGraphPage: React.FC = () => {
                 return <BoxGraph key={barChart.title} {...barChart} />;
               })}
             </BarChartList>
+            <IncomeExpenditureSwitch>
+              <CategoryNoDependency
+                bgColor={color.naverGreen}
+                text={pieGraphStore.incomeMode ? text.showExpenditure : text.showIncome}
+                onClick={switchIncomeExpenditure}
+              ></CategoryNoDependency>
+            </IncomeExpenditureSwitch>
           </BarChartWrapper>
         </>
       )}

--- a/client/src/pages/statistics-page/PieGraphPage.tsx
+++ b/client/src/pages/statistics-page/PieGraphPage.tsx
@@ -10,7 +10,8 @@ import NotFoundTransaction from '../../components/common/not-found-transaction/N
 import { numberWithCommas } from '../../utils/number';
 import BoxGraph from '../../components/graph/box-graph/BoxGraph';
 import CategoryNoDependency from '../../components/common/category/CategoryNoDependency';
-import { text, color } from '../../constants/pieGraphPage';
+import { text } from '../../constants/pieGraphPage';
+import color from '../../constants/color';
 
 const PieGraphPageWrapper = styled.div`
   margin: 0 auto;
@@ -63,7 +64,11 @@ const IncomeExpenditureSwitch = styled.div`
   bottom: 5%;
 `;
 
-const PieGraphPage: React.FC = () => {
+interface IPieGraphPage {
+  changePage: (change: boolean) => void;
+}
+
+const PieGraphPage: React.FC<IPieGraphPage> = ({ changePage }: IPieGraphPage) => {
   const { rootStore } = useStore();
   const id = useGetParam();
   const pieGraphStore = rootStore.pieGraphPageStore;
@@ -88,7 +93,7 @@ const PieGraphPage: React.FC = () => {
         <DropdownWrapper>
           <SingleInputDropDown
             items={pieGraphStore.dateOptions}
-            placeholder={text.dateInputPlaceholder}
+            placeholder={text.DATE_INPUT_PLACEHOLDER}
             defaultSelectValue={pieGraphStore.selectedDate}
             onChange={selectDateChanged}
           />
@@ -110,7 +115,7 @@ const PieGraphPage: React.FC = () => {
           </PieGraphWrapper>
           <BarChartWrapper>
             <BarChartHeaderWrapper>
-              <BarChartHeader>{pieGraphStore.incomeMode ? text.totalExpenditure : text.totalIncome}</BarChartHeader>
+              <BarChartHeader>{pieGraphStore.incomeMode ? text.TOTAL_EXPENDITURE : text.TOTAL_INCOME}</BarChartHeader>
               <BarChartHeader>
                 {pieGraphStore.incomeMode
                   ? '-' + numberWithCommas(pieGraphStore.totalValue)
@@ -124,8 +129,8 @@ const PieGraphPage: React.FC = () => {
             </BarChartList>
             <IncomeExpenditureSwitch>
               <CategoryNoDependency
-                bgColor={color.naverGreen}
-                text={pieGraphStore.incomeMode ? text.showExpenditure : text.showIncome}
+                bgColor={color.NAVER_GREEN}
+                text={pieGraphStore.incomeMode ? text.SHOW_EXPENDITURE : text.SHOW_INCOME}
                 onClick={switchIncomeExpenditure}
               ></CategoryNoDependency>
             </IncomeExpenditureSwitch>

--- a/client/src/pages/statistics-page/PieGraphPage.tsx
+++ b/client/src/pages/statistics-page/PieGraphPage.tsx
@@ -65,12 +65,8 @@ const IncomeExpenditureSwitch = styled.div`
 
 const PieGraphPage: React.FC = () => {
   const { rootStore } = useStore();
-  console.log('re rendered');
   const id = useGetParam();
   const pieGraphStore = rootStore.pieGraphPageStore;
-  console.log(pieGraphStore.transactions);
-  console.log(pieGraphStore.pieChartValue);
-  console.log(pieGraphStore.boxChartValue);
   useEffect(() => {
     pieGraphStore.loadTransactions(id);
   }, []);

--- a/client/src/pages/statistics-page/PieGraphPage.tsx
+++ b/client/src/pages/statistics-page/PieGraphPage.tsx
@@ -7,7 +7,8 @@ import { observer } from 'mobx-react';
 import useGetParam from '../../hook/use-get-param/useGetParam';
 import PieGraph from '../../components/graph/pie/PieGraph';
 import NotFoundTransaction from '../../components/common/not-found-transaction/NotFoundTransaction';
-
+import { numberWithCommas } from '../../utils/number';
+import BoxGraph from '../../components/graph/box-graph/BoxGraph';
 const PieGraphPageWrapper = styled.div`
   margin: 0 auto;
   width: 70%;
@@ -31,7 +32,26 @@ const InputWrapper = styled.div`
 const PieGraphWrapper = styled.div`
   margin: 0 auto;
   margin-top: -5%;
-  width: 70%;
+  width: 55%;
+`;
+
+const BarChartWrapper = styled.div`
+  margin-top: 2em;
+`;
+
+const BarChartHeaderWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  border-bottom: 2px solid lightgray;
+`;
+
+const BarChartHeader = styled.p`
+  font-size: 1.2em;
+`;
+
+const BarChartList = styled.ul`
+  padding: 0;
 `;
 
 const PieGraphPage: React.FC = () => {
@@ -76,9 +96,26 @@ const PieGraphPage: React.FC = () => {
       {pieGraphStore.transactions.length === 0 ? (
         <NotFoundTransaction />
       ) : (
-        <PieGraphWrapper>
-          <PieGraph transactionData={pieGraphStore.pieChartValue} />
-        </PieGraphWrapper>
+        <>
+          <PieGraphWrapper>
+            <PieGraph transactionData={pieGraphStore.pieChartValue} />
+          </PieGraphWrapper>
+          <BarChartWrapper>
+            <BarChartHeaderWrapper>
+              <BarChartHeader>{pieGraphStore.incomeMode ? '총 지출' : '총 수입'}</BarChartHeader>
+              <BarChartHeader>
+                {pieGraphStore.incomeMode
+                  ? '-' + numberWithCommas(pieGraphStore.totalValue)
+                  : '+' + numberWithCommas(pieGraphStore.totalValue)}
+              </BarChartHeader>
+            </BarChartHeaderWrapper>
+            <BarChartList>
+              {pieGraphStore.boxChartValue.map((barChart) => {
+                return <BoxGraph key={barChart.title} {...barChart} />;
+              })}
+            </BarChartList>
+          </BarChartWrapper>
+        </>
       )}
     </PieGraphPageWrapper>
   );

--- a/client/src/pages/statistics-page/StatisticsPage.tsx
+++ b/client/src/pages/statistics-page/StatisticsPage.tsx
@@ -6,6 +6,11 @@ import { smallAccountbookItems } from '../../__dummy-data__/components/smallAcco
 import PieGraphPage from './PieGraphPage';
 import styled from 'styled-components';
 
+const PageWrapper = styled.div`
+  margin: 100px auto;
+  width: 70%;
+`;
+
 const StatisticsPage: React.FC = () => {
   return (
     <>
@@ -13,6 +18,9 @@ const StatisticsPage: React.FC = () => {
       <HeaderNavigationRightTopWrapper>
         <HeaderNavigation currentPage={'statistics'} />
       </HeaderNavigationRightTopWrapper>
+      <PageWrapper>
+        <PieGraphPage />
+      </PageWrapper>
     </>
   );
 };

--- a/client/src/pages/statistics-page/StatisticsPage.tsx
+++ b/client/src/pages/statistics-page/StatisticsPage.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import HeaderNavigation from '../../components/common/header-navigation/HeaderNavigation';
 import HeaderNavigationRightTopWrapper from '../../components/common/header-navigation/HeaderNavigationRightTop';
 import Sidebar from '../../components/common/sidebar/Sidebar';
@@ -12,6 +12,7 @@ const PageWrapper = styled.div`
 `;
 
 const StatisticsPage: React.FC = () => {
+  const [pieGraph, setPieGraph] = useState<boolean>(true);
   return (
     <>
       <Sidebar smallAccountbooks={smallAccountbookItems} />
@@ -19,7 +20,7 @@ const StatisticsPage: React.FC = () => {
         <HeaderNavigation currentPage={'statistics'} />
       </HeaderNavigationRightTopWrapper>
       <PageWrapper>
-        <PieGraphPage />
+        <PieGraphPage changePage={setPieGraph} />
       </PageWrapper>
     </>
   );

--- a/client/src/pages/transaction-page/TransactionPage.tsx
+++ b/client/src/pages/transaction-page/TransactionPage.tsx
@@ -27,7 +27,6 @@ const TransactionPage: React.FC<Props> = ({ match, location }: Props) => {
     rootStore.categoryStore.updateExpenditureCategories(accountbookId);
     rootStore.modalStore.formFilterStore.init();
   }, []);
-
   return (
     <PageWrapper>
       <TransactionView accountbookId={accountbookId} query={query} />

--- a/client/src/store/PieGraphPageStore.tsx
+++ b/client/src/store/PieGraphPageStore.tsx
@@ -61,6 +61,11 @@ export default class PieGraphPageStore {
     this.dateChange(this.endDate, nextDate, accountbookId);
   };
 
+  @action
+  switchIncomeMode = (): void => {
+    this.incomeMode = !this.incomeMode;
+  };
+
   dateChange = flow(function* (this: PieGraphPageStore, startDate: Date, endDate: Date, accountbookId: number) {
     this.startDate = startDate;
     this.endDate = endDate;

--- a/client/src/store/PieGraphPageStore.tsx
+++ b/client/src/store/PieGraphPageStore.tsx
@@ -4,7 +4,10 @@ import Expenditure from '../types/expenditure';
 import { dateOptions } from '../__dummy-data__/store/formFilterStore';
 import { action, makeObservable, observable, computed, flow } from 'mobx';
 import datePeriod, { datePeriodNumber } from '../constants/datePeriod';
-
+import transactionService from '../services/transaction';
+import PieChartValue from '../types/pieChartValue';
+import { getOnlyIncome, getTopFiveCategory, getOnlyExpenditure } from '../utils/filter';
+import BoxChartValue from '../types/boxChartValue';
 export default class PieGraphPageStore {
   rootStore: RootStore;
   dateOptions = dateOptions;
@@ -19,6 +22,9 @@ export default class PieGraphPageStore {
   startDate: Date;
 
   @observable
+  incomeMode = false;
+
+  @observable
   endDate: Date;
   constructor(rootStore: RootStore) {
     this.rootStore = rootStore;
@@ -30,30 +36,43 @@ export default class PieGraphPageStore {
   }
 
   @action
-  changeSelectedDate = (selectedType: string): void => {
+  changeSelectedDate = (selectedType: string, accountbookId: number): void => {
     this.selectedDate = selectedType;
-    this.startDate = this.getBeforeDateByPeriod(this.endDate, selectedType);
+    const prevDate = this.getBeforeDateByPeriod(this.endDate, selectedType);
+    this.dateChange(prevDate, this.endDate, accountbookId);
     if (selectedType === datePeriod.ALL) {
-      this.endDate = new Date();
-      this.startDate = new Date(0);
+      this.dateChange(new Date(0), new Date(), accountbookId);
     }
   };
 
   @action
-  moveToPrev = (): void => {
-    this.endDate = this.startDate;
-    this.startDate = this.getBeforeDateByPeriod(this.endDate, this.selectedDate);
+  moveToPrev = (accountbookId: number): void => {
+    const endDate = this.startDate;
+    const startDate = this.getBeforeDateByPeriod(endDate, this.selectedDate);
+    this.dateChange(startDate, endDate, accountbookId);
   };
 
   @action
-  moveToNext = (): void => {
+  moveToNext = (accountbookId: number): void => {
     const nextDate = this.getNextDateByPeriod(this.endDate, this.selectedDate);
     if (nextDate.valueOf() > new Date().valueOf()) {
       return;
     }
-    this.startDate = this.endDate;
-    this.endDate = nextDate;
+    this.dateChange(this.endDate, nextDate, accountbookId);
   };
+
+  dateChange = flow(function* (this: PieGraphPageStore, startDate: Date, endDate: Date, accountbookId: number) {
+    this.startDate = startDate;
+    this.endDate = endDate;
+    const transactions = yield transactionService.getTransactions(accountbookId, startDate, endDate);
+    this.transactions = transactions;
+  });
+
+  loadTransactions = flow(function* (this: PieGraphPageStore, accountbookId: number) {
+    const transactions = yield transactionService.getTransactions(accountbookId, this.startDate, this.endDate);
+    this.transactions = transactions;
+    console.log(transactions);
+  });
 
   getBeforeDateByPeriod = (endDate: Date, selectedType: string): Date => {
     const result = new Date(endDate.valueOf());
@@ -77,6 +96,33 @@ export default class PieGraphPageStore {
       this.startDate.getMonth() + 1
     }월 ${this.startDate.getDate()}일 ~ ${this.endDate.getFullYear()}년 ${
       this.endDate.getMonth() + 1
-    }월 ${this.endDate.getDate()}알`;
+    }월 ${this.endDate.getDate()}일`;
+  }
+
+  @computed
+  get pieChartValue(): PieChartValue[] {
+    const targetTransactions = this.incomeMode
+      ? getOnlyIncome(this.transactions)
+      : getOnlyExpenditure(this.transactions);
+
+    const topOfFive = getTopFiveCategory(targetTransactions);
+    return topOfFive;
+  }
+
+  @computed
+  get boxChartValue(): BoxChartValue[] {
+    const targetTransactions = this.incomeMode
+      ? getOnlyIncome(this.transactions)
+      : getOnlyExpenditure(this.transactions);
+
+    const topOfFive = getTopFiveCategory(targetTransactions);
+    return topOfFive;
+  }
+
+  @computed
+  get totalValue(): number {
+    return this.transactions.reduce((acc, curr) => {
+      return acc + curr.amount;
+    }, 0);
   }
 }

--- a/client/src/store/PieGraphPageStore.tsx
+++ b/client/src/store/PieGraphPageStore.tsx
@@ -76,7 +76,6 @@ export default class PieGraphPageStore {
   loadTransactions = flow(function* (this: PieGraphPageStore, accountbookId: number) {
     const transactions = yield transactionService.getTransactions(accountbookId, this.startDate, this.endDate);
     this.transactions = transactions;
-    console.log(transactions);
   });
 
   getBeforeDateByPeriod = (endDate: Date, selectedType: string): Date => {

--- a/client/src/types/category.ts
+++ b/client/src/types/category.ts
@@ -10,4 +10,10 @@ export interface CategoryRequest {
   color: string;
 }
 
+export interface ICategoryValue {
+  title: string;
+  color: string;
+  value: number;
+}
+
 export default Category;

--- a/client/src/utils/filter.ts
+++ b/client/src/utils/filter.ts
@@ -167,5 +167,15 @@ export function getTopFiveCategory(transactions: Array<Income | Expenditure>): B
     endOfFive.ratio = (endOfFive.value * 100) / totalValue;
   }
 
+  topOfFive.sort(function (transactionPrev: BoxChartValue, transactionNext: BoxChartValue) {
+    if (transactionPrev.ratio > transactionNext.ratio) {
+      return -1;
+    }
+    if (transactionPrev.ratio === transactionNext.ratio) {
+      return 0;
+    }
+    return 1;
+  });
+
   return topOfFive;
 }

--- a/client/src/utils/filter.ts
+++ b/client/src/utils/filter.ts
@@ -1,6 +1,9 @@
-import Income from '../types/income';
+import Income, { isIncome } from '../types/income';
 import Expenditure from '../types/expenditure';
 import Query from '../types/query';
+import BoxChartValue from '../types/boxChartValue';
+import { transaction } from 'mobx';
+import { ICategoryValue } from '../types/category';
 
 export const filtering = (
   transactions: Array<Income | Expenditure>,
@@ -73,3 +76,96 @@ const accountFilter = (
   });
   return filteredTransactions;
 };
+
+export const getOnlyIncome = (transactions: Array<Income | Expenditure>): Array<Income> => {
+  const result: Income[] = [];
+  transactions.forEach((transaction) => {
+    if (isIncome(transaction)) {
+      result.push(transaction);
+    }
+  });
+  return result;
+};
+
+export const getOnlyExpenditure = (transactions: Array<Income | Expenditure>): Array<Expenditure> => {
+  const result: Expenditure[] = [];
+  transactions.forEach((transaction) => {
+    if (!isIncome(transaction)) {
+      result.push(transaction);
+    }
+  });
+  return result;
+};
+
+const getCategoryList = (
+  transactions: Array<Income | Expenditure>,
+): [memorized: Map<string, ICategoryValue>, totalValue: number] => {
+  const memorized = new Map<string, ICategoryValue>();
+  let totalValue = 0;
+
+  transactions.forEach((transaction) => {
+    const name = transaction.category.name;
+    const color = transaction.category.color;
+    const value = transaction.amount;
+
+    if (!memorized.has(name)) {
+      memorized.set(name, {
+        title: name,
+        color: color,
+        value: 0,
+      });
+    }
+    totalValue += value;
+    const out = memorized.get(name);
+    if (out !== undefined) {
+      out.value += value;
+    }
+  });
+  return [memorized, totalValue];
+};
+
+const getTopOfFiveList = (
+  categoryList: ICategoryValue[],
+  totalValue: number,
+): [topOfFive: BoxChartValue[], remain: BoxChartValue[]] => {
+  const categoryListWithRatio = categoryList.map((category) => {
+    return {
+      ...category,
+      ratio: (category.value / totalValue) * 100,
+    };
+  });
+
+  categoryListWithRatio.sort(function (a, b) {
+    if (a.value < b.value) {
+      return -1;
+    }
+    return 0;
+  });
+
+  return [categoryListWithRatio.slice(0, 5), categoryListWithRatio.slice(5)];
+};
+
+export function getTopFiveCategory(transactions: Array<Income | Expenditure>): BoxChartValue[] {
+  const [memorized, totalValue] = getCategoryList(transactions);
+
+  if (totalValue === 0) {
+    return [];
+  }
+
+  const categoryList = Array.from(memorized).map(([name, value]) => value);
+
+  const [topOfFive, remain] = getTopOfFiveList(categoryList, totalValue);
+
+  if (categoryList.length > 5) {
+    const endOfFive = topOfFive[4];
+    endOfFive.title = '기타';
+
+    remain.forEach((transaction) => {
+      endOfFive.value += transaction.value;
+    });
+
+    endOfFive.ratio = (endOfFive.value * 100) / totalValue;
+  }
+
+  return topOfFive;
+}


### PR DESCRIPTION
## 관련 이슈
#212 #214 #215 

## 구현 세부사항

![파이통계페이지](https://user-images.githubusercontent.com/49854357/101663382-fd55f200-3a8d-11eb-9fe8-73e2e80fb178.png)

만들어둔 PiePageStore와 드랍다운 박스, xx년xx월 ~ xx년 xx월이 표기된 인풋박스를 연결했습니다.

달이 변경될 때 마다 새로운 거래내역을 불러오는 로직을 추가하였습니다.

거래내역에서 상위 5개의 카테고리를 축출해내는 코드를 생성했고 상위 5개의 카테고리을 파이그래프와 박스형태의 그래프로
화면에 출력하는 부분을 생성했습니다.

@boostcamp-2020/accountbook_mentor 
