### PR TITLE
가계부 선택 페이지 생성중 ...

### DIFF
--- a/client/src/components/accountbook-selection-page/accontbook-setting/AccountbookSetting.stories.tsx
+++ b/client/src/components/accountbook-selection-page/accontbook-setting/AccountbookSetting.stories.tsx
@@ -20,7 +20,7 @@ export const WhiteItem = (): JSX.Element => {
   const tempColor1 = '#000000';
   return (
     <TempDiv bgColor={tempColor1}>
-      <AccountbookSetting accountbookId={1} bgColor={tempColor1} />
+      <AccountbookSetting id={1} bgColor={tempColor1} />
     </TempDiv>
   );
 };
@@ -29,7 +29,7 @@ export const BlackItem = (): JSX.Element => {
   const tempColor2 = '#E0F8EC';
   return (
     <TempDiv bgColor={tempColor2}>
-      <AccountbookSetting accountbookId={2} bgColor={tempColor2} />
+      <AccountbookSetting id={2} bgColor={tempColor2} />
     </TempDiv>
   );
 };

--- a/client/src/components/accountbook-selection-page/accontbook-setting/AccountbookSetting.stories.tsx
+++ b/client/src/components/accountbook-selection-page/accontbook-setting/AccountbookSetting.stories.tsx
@@ -20,7 +20,7 @@ export const WhiteItem = (): JSX.Element => {
   const tempColor1 = '#000000';
   return (
     <TempDiv bgColor={tempColor1}>
-      <AccountbookSetting bgColor={tempColor1} />
+      <AccountbookSetting accountbookId={1} bgColor={tempColor1} />
     </TempDiv>
   );
 };
@@ -29,7 +29,7 @@ export const BlackItem = (): JSX.Element => {
   const tempColor2 = '#E0F8EC';
   return (
     <TempDiv bgColor={tempColor2}>
-      <AccountbookSetting bgColor={tempColor2} />
+      <AccountbookSetting accountbookId={2} bgColor={tempColor2} />
     </TempDiv>
   );
 };

--- a/client/src/components/accountbook-selection-page/accontbook-setting/AccountbookSetting.tsx
+++ b/client/src/components/accountbook-selection-page/accontbook-setting/AccountbookSetting.tsx
@@ -1,25 +1,40 @@
 import React from 'react';
 import styled from 'styled-components';
 import { getTextColor } from '../../../utils/color';
+import { BLUE, NAVER_GREEN } from '../../../constants/color';
 
-const Wrapper = styled.div<{ itemColor: string }>`
+const Wrapper = styled.div<{ itemColor: string; bgColor: string }>`
   width: 1rem;
   height: 1rem;
   box-sizing: border-box;
   .setting {
     fill: ${({ itemColor }) => itemColor};
   }
+  /* &:hover .setting {
+    fill: ${({ bgColor }) => {
+    return bgColor === BLUE ? NAVER_GREEN : BLUE;
+  }};
+  } */
+  &:hover .setting {
+    fill: ${BLUE};
+    stroke: ${({ bgColor, itemColor }) => {
+      return bgColor === BLUE ? itemColor : null;
+    }};
+    stroke-width: ${({ bgColor }) => {
+      return bgColor === BLUE ? '1px' : null;
+    }};
+  }
 `;
 
 interface SettingProps {
-  accountbookId: number;
+  id: number;
   bgColor: string;
 }
 
-const AccountbookSetting = ({ accountbookId, bgColor }: SettingProps): JSX.Element => {
+const AccountbookSetting = ({ id, bgColor }: SettingProps): JSX.Element => {
   const itemColor = getTextColor(bgColor);
   return (
-    <Wrapper itemColor={itemColor}>
+    <Wrapper itemColor={itemColor} bgColor={bgColor}>
       <svg viewBox="0 0 24 24" className="setting">
         <path d="m22.683 9.394-1.88-.239c-.155-.477-.346-.937-.569-1.374l1.161-1.495c.47-.605.415-1.459-.122-1.979l-1.575-1.575c-.525-.542-1.379-.596-1.985-.127l-1.493 1.161c-.437-.223-.897-.414-1.375-.569l-.239-1.877c-.09-.753-.729-1.32-1.486-1.32h-2.24c-.757 0-1.396.567-1.486 1.317l-.239 1.88c-.478.155-.938.345-1.375.569l-1.494-1.161c-.604-.469-1.458-.415-1.979.122l-1.575 1.574c-.542.526-.597 1.38-.127 1.986l1.161 1.494c-.224.437-.414.897-.569 1.374l-1.877.239c-.753.09-1.32.729-1.32 1.486v2.24c0 .757.567 1.396 1.317 1.486l1.88.239c.155.477.346.937.569 1.374l-1.161 1.495c-.47.605-.415 1.459.122 1.979l1.575 1.575c.526.541 1.379.595 1.985.126l1.494-1.161c.437.224.897.415 1.374.569l.239 1.876c.09.755.729 1.322 1.486 1.322h2.24c.757 0 1.396-.567 1.486-1.317l.239-1.88c.477-.155.937-.346 1.374-.569l1.495 1.161c.605.47 1.459.415 1.979-.122l1.575-1.575c.542-.526.597-1.379.127-1.985l-1.161-1.494c.224-.437.415-.897.569-1.374l1.876-.239c.753-.09 1.32-.729 1.32-1.486v-2.24c.001-.757-.566-1.396-1.316-1.486zm-10.683 7.606c-2.757 0-5-2.243-5-5s2.243-5 5-5 5 2.243 5 5-2.243 5-5 5z" />
       </svg>

--- a/client/src/components/accountbook-selection-page/accontbook-setting/AccountbookSetting.tsx
+++ b/client/src/components/accountbook-selection-page/accontbook-setting/AccountbookSetting.tsx
@@ -11,11 +11,12 @@ const Wrapper = styled.div<{ itemColor: string }>`
   }
 `;
 
-interface CategoryProps {
+interface SettingProps {
+  accountbookId: number;
   bgColor: string;
 }
 
-const AccountbookSetting = ({ bgColor }: CategoryProps): JSX.Element => {
+const AccountbookSetting = ({ accountbookId, bgColor }: SettingProps): JSX.Element => {
   const itemColor = getTextColor(bgColor);
   return (
     <Wrapper itemColor={itemColor}>

--- a/client/src/components/accountbook-selection-page/accountbook-card/AccountbookCard.stories.tsx
+++ b/client/src/components/accountbook-selection-page/accountbook-card/AccountbookCard.stories.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import styled from 'styled-components';
 import AccountbookCard from './AccountbookCard';
 
 export default {
@@ -6,29 +7,53 @@ export default {
   component: AccountbookCard,
 };
 
+const ViewWrapper = styled.div`
+  width: 40%;
+  padding-top: 5%;
+  margin: 0 auto;
+`;
+
 export const WhiteTextAccountbookCard = (): JSX.Element => {
-  return <AccountbookCard id={1} name={'가계부1'} color={'#000000'} description={'가계부1 설명'} />;
+  return (
+    <ViewWrapper>
+      <AccountbookCard id={1} title={'가계부1'} color={'#000000'} description={'가계부1 설명'} />
+    </ViewWrapper>
+  );
 };
 
 export const BlackTextAccountbookCard = (): JSX.Element => {
-  return <AccountbookCard id={2} name={'가계부2'} color={'#E0F8EC'} description={'가계부2 설명'} />;
+  return (
+    <ViewWrapper>
+      <AccountbookCard id={2} title={'가계부2'} color={'#E0F8EC'} description={'가계부2 설명'} />
+    </ViewWrapper>
+  );
 };
 
 export const BlueBackgroundAccountbookCard = (): JSX.Element => {
-  return <AccountbookCard id={3} name={'가계부2'} color={'#1EA7FD'} description={'가계부3 설명'} />;
+  return (
+    <ViewWrapper>
+      <AccountbookCard id={3} title={'가계부3'} color={'#1EA7FD'} description={'가계부3 설명'} />
+    </ViewWrapper>
+  );
 };
 
 export const RedBackgroundAccountbookCard = (): JSX.Element => {
-  return <AccountbookCard id={4} name={'가계부2'} color={'#F35454'} description={'가계부4 설명'} />;
+  return (
+    <ViewWrapper>
+      <AccountbookCard id={4} title={'가계부4'} color={'#F35454'} description={'가계부4 설명'} />
+    </ViewWrapper>
+  );
 };
 
 export const LongTextAccountbookCard = (): JSX.Element => {
   return (
-    <AccountbookCard
-      id={5}
-      name={'가계부가계부가계부가계부가계부'}
-      color={'#E0F8EC'}
-      description={'30자맞춘테스트설명30자맞춘테스트설명30자맞춘테스트설명'}
-    />
+    <ViewWrapper>
+      <AccountbookCard
+        id={5}
+        title={'가계부가계부가계부가계부가계부'}
+        color={'#E0F8EC'}
+        description={'30자맞춘테스트설명30자맞춘테스트설명30자맞춘테스트설명'}
+      />
+    </ViewWrapper>
   );
 };

--- a/client/src/components/accountbook-selection-page/accountbook-card/AccountbookCard.stories.tsx
+++ b/client/src/components/accountbook-selection-page/accountbook-card/AccountbookCard.stories.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import AccountbookCard from './AccountbookCard';
+
+export default {
+  title: 'Accountbook-Selection-Page/AccountbookCard',
+  component: AccountbookCard,
+};
+
+export const WhiteTextAccountbookCard = (): JSX.Element => {
+  return <AccountbookCard id={1} name={'가계부1'} color={'#000000'} description={'가계부1 설명'} />;
+};
+
+export const BlackTextAccountbookCard = (): JSX.Element => {
+  return <AccountbookCard id={2} name={'가계부2'} color={'#E0F8EC'} description={'가계부2 설명'} />;
+};
+
+export const BlueBackgroundAccountbookCard = (): JSX.Element => {
+  return <AccountbookCard id={3} name={'가계부2'} color={'#1EA7FD'} description={'가계부3 설명'} />;
+};
+
+export const RedBackgroundAccountbookCard = (): JSX.Element => {
+  return <AccountbookCard id={4} name={'가계부2'} color={'#F35454'} description={'가계부4 설명'} />;
+};
+
+export const LongTextAccountbookCard = (): JSX.Element => {
+  return (
+    <AccountbookCard
+      id={5}
+      name={'가계부가계부가계부가계부가계부'}
+      color={'#E0F8EC'}
+      description={'30자맞춘테스트설명30자맞춘테스트설명30자맞춘테스트설명'}
+    />
+  );
+};

--- a/client/src/components/accountbook-selection-page/accountbook-card/AccountbookCard.tsx
+++ b/client/src/components/accountbook-selection-page/accountbook-card/AccountbookCard.tsx
@@ -19,16 +19,17 @@ const AccountbookWrapper = styled.div<{
   min-height: 100px;
   background-color: ${({ bgColor }) => bgColor};
   color: ${({ textColor }) => textColor};
-  padding: 15px;
+  padding: 15px 15px 20px 15px;
   display: flex;
   cursor: pointer;
   &:hover {
     box-shadow: 2px 3px 7px gray;
   }
   border-radius: 10px;
+  flex-direction: column;
 `;
 
-const ElementsWrapper = styled.div`
+const HeaderWrapper = styled.div`
   display: flex;
   margin-left: auto;
 `;
@@ -37,19 +38,27 @@ const ElementWrapper = styled.div`
   padding-left: 10px;
 `;
 
+const TitleWrapper = styled.div`
+  font-size: 1.5rem;
+  font-weight: 500;
+  padding-bottom: 10px;
+`;
+
 const AccountbookCard = (accountbook: Accountbook): JSX.Element => {
   const { rootStore } = useStore();
   const textColor = getTextColor(accountbook.color);
   return (
     <AccountbookWrapper bgColor={accountbook.color} textColor={textColor}>
-      <ElementsWrapper>
+      <HeaderWrapper>
         <ElementWrapper>
           <AccountbookSetting id={accountbook.id} bgColor={accountbook.color} />
         </ElementWrapper>
         <ElementWrapper>
           <AccountbookElimination id={accountbook.id} bgColor={accountbook.color} />
         </ElementWrapper>
-      </ElementsWrapper>
+      </HeaderWrapper>
+      <TitleWrapper>{accountbook.title}</TitleWrapper>
+      {accountbook.description}
     </AccountbookWrapper>
   );
 };

--- a/client/src/components/accountbook-selection-page/accountbook-card/AccountbookCard.tsx
+++ b/client/src/components/accountbook-selection-page/accountbook-card/AccountbookCard.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import styled from 'styled-components';
+import AccountbookSetting from '../accontbook-setting/AccountbookSetting';
+import AccountbookElimination from '../accountbook-elimination/AccountbookElimination';
+
+import { getTextColor } from '../../../utils/color';
+import useStore from '../../../hook/use-store/useStore';
+import { Accountbook } from '../../../types/accountbook';
+
+const AccountbookWrapper = styled.div<{
+  bgColor: string;
+  textColor: string;
+}>`
+  box-sizing: border-box;
+  width: 100%;
+  min-width: 80px;
+  height: 100%;
+  max-height: 200px;
+  min-height: 100px;
+  background-color: ${({ bgColor }) => bgColor};
+  color: ${({ textColor }) => textColor};
+  padding: 15px;
+  display: flex;
+  cursor: pointer;
+  &:hover {
+    box-shadow: 2px 3px 7px gray;
+  }
+  border-radius: 10px;
+`;
+
+const ElementsWrapper = styled.div`
+  display: flex;
+  margin-left: auto;
+`;
+
+const ElementWrapper = styled.div`
+  padding-left: 10px;
+`;
+
+const AccountbookCard = (accountbook: Accountbook): JSX.Element => {
+  const { rootStore } = useStore();
+  const textColor = getTextColor(accountbook.color);
+  return (
+    <AccountbookWrapper bgColor={accountbook.color} textColor={textColor}>
+      <ElementsWrapper>
+        <ElementWrapper>
+          <AccountbookSetting id={accountbook.id} bgColor={accountbook.color} />
+        </ElementWrapper>
+        <ElementWrapper>
+          <AccountbookElimination id={accountbook.id} bgColor={accountbook.color} />
+        </ElementWrapper>
+      </ElementsWrapper>
+    </AccountbookWrapper>
+  );
+};
+
+export default AccountbookCard;

--- a/client/src/components/accountbook-selection-page/accountbook-elimination/AccountbookElimination.stories.tsx
+++ b/client/src/components/accountbook-selection-page/accountbook-elimination/AccountbookElimination.stories.tsx
@@ -20,7 +20,7 @@ export const WhiteItem = (): JSX.Element => {
   const tempColor1 = '#000000';
   return (
     <TempDiv bgColor={tempColor1}>
-      <AccountbookElimination bgColor={tempColor1} />
+      <AccountbookElimination accountbookId={1} bgColor={tempColor1} />
     </TempDiv>
   );
 };
@@ -29,7 +29,7 @@ export const BlackItem = (): JSX.Element => {
   const tempColor2 = '#E0F8EC';
   return (
     <TempDiv bgColor={tempColor2}>
-      <AccountbookElimination bgColor={tempColor2} />
+      <AccountbookElimination accountbookId={2} bgColor={tempColor2} />
     </TempDiv>
   );
 };

--- a/client/src/components/accountbook-selection-page/accountbook-elimination/AccountbookElimination.stories.tsx
+++ b/client/src/components/accountbook-selection-page/accountbook-elimination/AccountbookElimination.stories.tsx
@@ -20,7 +20,7 @@ export const WhiteItem = (): JSX.Element => {
   const tempColor1 = '#000000';
   return (
     <TempDiv bgColor={tempColor1}>
-      <AccountbookElimination accountbookId={1} bgColor={tempColor1} />
+      <AccountbookElimination id={1} bgColor={tempColor1} />
     </TempDiv>
   );
 };
@@ -29,7 +29,7 @@ export const BlackItem = (): JSX.Element => {
   const tempColor2 = '#E0F8EC';
   return (
     <TempDiv bgColor={tempColor2}>
-      <AccountbookElimination accountbookId={2} bgColor={tempColor2} />
+      <AccountbookElimination id={2} bgColor={tempColor2} />
     </TempDiv>
   );
 };

--- a/client/src/components/accountbook-selection-page/accountbook-elimination/AccountbookElimination.tsx
+++ b/client/src/components/accountbook-selection-page/accountbook-elimination/AccountbookElimination.tsx
@@ -1,25 +1,40 @@
 import React from 'react';
 import styled from 'styled-components';
 import { getTextColor } from '../../../utils/color';
+import { RED, NAVER_GREEN } from '../../../constants/color';
 
-const Wrapper = styled.div<{ itemColor: string }>`
+const Wrapper = styled.div<{ itemColor: string; bgColor: string }>`
   width: 1rem;
   height: 1rem;
   box-sizing: border-box;
   .elimination {
     fill: ${({ itemColor }) => itemColor};
   }
+  /* &:hover .elimination {
+    fill: ${({ bgColor }) => {
+    return bgColor === RED ? NAVER_GREEN : RED;
+  }};
+  } */
+  &:hover .elimination {
+    fill: ${RED};
+    stroke: ${({ bgColor, itemColor }) => {
+      return bgColor === RED ? itemColor : null;
+    }};
+    stroke-width: ${({ bgColor }) => {
+      return bgColor === RED ? '10px' : null;
+    }};
+  }
 `;
 
 interface SettingProps {
-  accountbookId: number;
+  id: number;
   bgColor: string;
 }
 
-const AccountbookElimination = ({ accountbookId, bgColor }: SettingProps): JSX.Element => {
+const AccountbookElimination = ({ id, bgColor }: SettingProps): JSX.Element => {
   const itemColor = getTextColor(bgColor);
   return (
-    <Wrapper itemColor={itemColor}>
+    <Wrapper itemColor={itemColor} bgColor={bgColor}>
       <svg viewBox="0 0 329.26933 329" className="elimination">
         <path d="m194.800781 164.769531 128.210938-128.214843c8.34375-8.339844 8.34375-21.824219 0-30.164063-8.339844-8.339844-21.824219-8.339844-30.164063 0l-128.214844 128.214844-128.210937-128.214844c-8.34375-8.339844-21.824219-8.339844-30.164063 0-8.34375 8.339844-8.34375 21.824219 0 30.164063l128.210938 128.214843-128.210938 128.214844c-8.34375 8.339844-8.34375 21.824219 0 30.164063 4.15625 4.160156 9.621094 6.25 15.082032 6.25 5.460937 0 10.921875-2.089844 15.082031-6.25l128.210937-128.214844 128.214844 128.214844c4.160156 4.160156 9.621094 6.25 15.082032 6.25 5.460937 0 10.921874-2.089844 15.082031-6.25 8.34375-8.339844 8.34375-21.824219 0-30.164063zm0 0" />
       </svg>

--- a/client/src/components/accountbook-selection-page/accountbook-elimination/AccountbookElimination.tsx
+++ b/client/src/components/accountbook-selection-page/accountbook-elimination/AccountbookElimination.tsx
@@ -11,11 +11,12 @@ const Wrapper = styled.div<{ itemColor: string }>`
   }
 `;
 
-interface CategoryProps {
+interface SettingProps {
+  accountbookId: number;
   bgColor: string;
 }
 
-const AccountbookElimination = ({ bgColor }: CategoryProps): JSX.Element => {
+const AccountbookElimination = ({ accountbookId, bgColor }: SettingProps): JSX.Element => {
   const itemColor = getTextColor(bgColor);
   return (
     <Wrapper itemColor={itemColor}>

--- a/client/src/components/accountbook-selection-page/add-accountbook-card/AddAccountbookCard.tsx
+++ b/client/src/components/accountbook-selection-page/add-accountbook-card/AddAccountbookCard.tsx
@@ -10,6 +10,10 @@ const DivWrapper = styled.div`
   display: flex;
   justify-content: center;
   background-color: ${GRAY};
+  cursor: pointer;
+  &:hover {
+    box-shadow: 2px 3px 7px gray;
+  }
 `;
 
 const AddAccountbookCard: React.FC = () => {

--- a/client/src/pages/accountbook-selection-page/AccountbookSelectionPage.stories.tsx
+++ b/client/src/pages/accountbook-selection-page/AccountbookSelectionPage.stories.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import AccountbookSelectionPage from './AccountbookSelectionPage';
+
+export default {
+  title: 'pages/accountbook-selection-Page/AccountbookSelectionPage',
+  component: AccountbookSelectionPage,
+};
+
+export const Default = (): JSX.Element => {
+  return <AccountbookSelectionPage />;
+};

--- a/client/src/pages/accountbook-selection-page/AccountbookSelectionPage.tsx
+++ b/client/src/pages/accountbook-selection-page/AccountbookSelectionPage.tsx
@@ -1,7 +1,24 @@
-import React from 'react';
+import React, { useEffect } from 'react';
+import useStore from '../../hook/use-store/useStore';
+import { observer } from 'mobx-react';
+import styled from 'styled-components';
+
+import AddAccountbookCard from '../../components/accountbook-selection-page/add-accountbook-card/AddAccountbookCard';
+
+const ViewWrapper = styled.div`
+  width: 40%;
+  padding-top: 5%;
+  margin: 0 auto;
+`;
 
 const AccountbookSelectionPage: React.FC = () => {
-  return <div>가계부 선택 페이지 임시</div>;
+  return (
+    <ViewWrapper>
+      <div>가계부 선택 페이지 임시</div>
+      <br />
+      <AddAccountbookCard />
+    </ViewWrapper>
+  );
 };
 
 export default AccountbookSelectionPage;

--- a/client/src/types/accountbook.ts
+++ b/client/src/types/accountbook.ts
@@ -1,0 +1,8 @@
+export interface Accountbook {
+  id: number;
+  name: string;
+  color: string;
+  description: string;
+}
+
+export default Accountbook;

--- a/client/src/types/accountbook.ts
+++ b/client/src/types/accountbook.ts
@@ -1,6 +1,6 @@
 export interface Accountbook {
   id: number;
-  name: string;
+  title: string;
   color: string;
   description: string;
 }


### PR DESCRIPTION
## 관련 이슈
#37 [가계부 선택 페이지] 가계부 컴포넌트

## 구현/수정 내용
- 가계부 선택 페이지를 만드는 중입니다... 가계부 선택하는 카드 view만 만들었습니다.
- 파비콘 한 번 만들어봤습니다. 아직 깃허브에 업로드하진 않았습니다. 아래처럼 생겼습니다.
<img src="https://i.imgur.com/Jg2Q3rR.png" width=150/>

새벽에 병화님이랑 가계부 설정 페이지 상태 및 css 처리하느라 제 것이 조금... 부진합니다ㅠㅠ 쉽지 않네요 인생...


## 추가 논의
- 사용자에게 가계부 선택 페이지에서 환경설정 아이콘이나 삭제 아이콘을 눌렀을 때 hover가 되었다는 것을 알려줘야 할 것 같은데, 어떠한 방식으로 처리해야 할지 감이 오지 않습니다... 일단 지금 임시 방편으로 다음과 같이 구현해놨습니다.

1. 일반적인 경우

![](https://i.imgur.com/iD6soH1.gif)
![](https://i.imgur.com/mVqTNE3.gif)
![](https://i.imgur.com/SmGGm6p.gif)

2. 가계부 선택 카드가 파란색이거나 빨간색일 때

![](https://i.imgur.com/tGcF0Vy.gif)
![](https://i.imgur.com/MMZFgGs.gif)

위처럼 테두리가 생기는 것은 정확히 Background color가 RED거나 BLUE일 때만 적용되는 것이라 유사한 빨간색이나 파란색이 나올 경우 테두리가 씌워지지 않는 문제가 있습니다. 애초에 좋은 방법도 아니고요ㅠㅠ 아이디어가 마땅히 떠오르지 않아서 헬프 요청합니다... 병화님이 말해주신 방법이 있는데 내일 오전에 한 번 같이 의논해봐야 할 것 같습니다. 병화님이 말씀해주신 방법은 솔직히 자신 없음여... ㅎ

@boostcamp-2020/accountbook_mentor 