### PR TITLE
결제 내역 문자 파싱 기능 BE 추가

### DIFF
--- a/server/src/__test__/services/sms-parsing.test.js
+++ b/server/src/__test__/services/sms-parsing.test.js
@@ -223,4 +223,22 @@ describe('----------롯데----------', () => {
       });
     });
   });
+
+  describe('Case 2. 승인 (쉼표가 두 번 이상 나오는 큰 숫자)', () => {
+    test('카드명: 롯데\n', () => {
+      expect(
+        parsingTextContent(`롯데1234 승인
+			1,235,200원 일시불
+			09/15 18:31
+			월드크리닝 롯데마트`),
+      ).toEqual({
+        cardname: '롯데',
+        amount: 1235200,
+        date: '09/15',
+        time: '18:31',
+        transactionType: '승인',
+        isDeposit: false,
+      });
+    });
+  });
 });

--- a/server/src/__test__/services/sms-parsing.test.js
+++ b/server/src/__test__/services/sms-parsing.test.js
@@ -1,139 +1,226 @@
 const { parsingTextContent } = require('@services/transaction');
 
-test('parsingTextContent', () => {
-  expect(
-    parsingTextContent(`[WEB발신]
-    KB국민카드 김영근님 06/07
-    09:22 5000원
-    결제 승인`),
-  ).toEqual({
-    cardname: 'KB',
-    amount: 5000,
-    date: '06/07',
-    time: '09:22',
-    transactionType: '승인',
-    isDeposit: false,
+describe('----------국민----------', () => {
+  describe('Case 1. 승인', () => {
+    test('카드명: KB국민카드\n', () => {
+      expect(
+        parsingTextContent(`[WEB발신]
+				KB국민카드 홍길동님 06/07
+				09:22 5000원
+				결제 승인`),
+      ).toEqual({
+        cardname: 'KB',
+        amount: 5000,
+        date: '06/07',
+        time: '09:22',
+        transactionType: '승인',
+        isDeposit: false,
+      });
+    });
   });
 
-  expect(
-    parsingTextContent(`[Web발신]
-    농협 입금 200원
-    06/11 22:29 123-1234-4567-12
-    잔액 200000원`),
-  ).toEqual({
-    cardname: '농협',
-    amount: 200,
-    date: '06/11',
-    time: '22:29',
-    transactionType: '승인',
-    isDeposit: true,
+  describe('Case 2. 거절', () => {
+    test('카드명: KB국민체크\n', () => {
+      expect(
+        parsingTextContent(`[Web발신]
+			KB국민체크
+			홍*동님
+			06/08 08:57
+			28,440원
+			11PAY 인증
+			승인취소
+			`),
+      ).toEqual({
+        cardname: 'KB',
+        amount: 28440,
+        date: '06/08',
+        time: '08:57',
+        transactionType: '취소',
+        isDeposit: true,
+      });
+    });
+  });
+});
+
+describe('----------우리----------', () => {
+  describe('Case 1. 승인', () => {
+    test('카드명: 우리\n', () => {
+      expect(
+        parsingTextContent(`[Web발신]
+			우리(8804) 체크승인
+			홍*동님
+			10,000원
+			11/03 10:03
+			스타벅스코리아`),
+      ).toEqual({
+        cardname: '우리',
+        amount: 10000,
+        date: '11/03',
+        time: '10:03',
+        transactionType: '승인',
+        isDeposit: false,
+      });
+    });
   });
 
-  expect(
-    parsingTextContent(`농협 출금 5000원
-    08/31 19:01 123-1234-1234-12
-    잔액 200000원`),
-  ).toEqual({
-    cardname: '농협',
-    amount: 5000,
-    date: '08/31',
-    time: '19:01',
-    transactionType: '승인',
-    isDeposit: false,
+  describe('Case 2. 취소', () => {
+    test('카드명: 우리\n', () => {
+      expect(
+        parsingTextContent(`[Web발신]
+			우리(4575)승인취소
+			홍*동님
+			4562원 일시불
+			12/07 20:29
+			네이버페이
+			누적123,456원`),
+      ).toEqual({
+        cardname: '우리',
+        amount: 4562,
+        date: '12/07',
+        time: '20:29',
+        transactionType: '취소',
+        isDeposit: true,
+      });
+    });
+  });
+});
+
+describe('----------농협----------', () => {
+  describe('Case 1. 승인', () => {
+    test('카드명: NH카드\n', () => {
+      expect(
+        parsingTextContent(`[Web발신]
+				NH카드1*3*승인
+				홍*동
+				12,350원 체크
+				12/06 20:37
+				세븐일레븐 별나라점
+				잔액222,210원`),
+      ).toEqual({
+        cardname: 'NH',
+        amount: 12350,
+        date: '12/06',
+        time: '20:37',
+        transactionType: '승인',
+        isDeposit: false,
+      });
+    });
   });
 
-  expect(
-    parsingTextContent(`현대 ZERO 승인
-  2,500원 일시불
-  04/10 13:15
-  코레일유통서울지사
-  누적 560,852원
-  0.7%할인`),
-  ).toEqual({
-    cardname: '현대',
-    amount: 2500,
-    date: '04/10',
-    time: '13:15',
-    transactionType: '승인',
-    isDeposit: false,
+  describe('Case 2. 입금', () => {
+    test('카드명: 농협\n', () => {
+      expect(
+        parsingTextContent(`[Web발신]
+				농협 입금 200원
+				06/11 22:29 123-1234-4567-12
+				잔액 200000원`),
+      ).toEqual({
+        cardname: '농협',
+        amount: 200,
+        date: '06/11',
+        time: '22:29',
+        transactionType: '승인',
+        isDeposit: true,
+      });
+    });
   });
 
-  expect(
-    parsingTextContent(`[Web발신]
-    [신한체크승인] 최*희(7062)
-    02/10 13:10
-    (금액)1,000원 PAYCO`),
-  ).toEqual({
-    cardname: '신한',
-    amount: 1000,
-    date: '02/10',
-    time: '13:10',
-    transactionType: '승인',
-    isDeposit: false,
+  describe('Case 3. 출금', () => {
+    test('카드명: 농협\n', () => {
+      expect(
+        parsingTextContent(`농협 출금 5000원
+				08/31 19:01 123-1234-1234-12
+				잔액 200000원`),
+      ).toEqual({
+        cardname: '농협',
+        amount: 5000,
+        date: '08/31',
+        time: '19:01',
+        transactionType: '승인',
+        isDeposit: false,
+      });
+    });
+  });
+});
+
+describe('----------현대----------', () => {
+  describe('Case 1. 승인', () => {
+    test('카드명: 현대 ZERO\n', () => {
+      expect(
+        parsingTextContent(`현대 ZERO 승인
+			2,500원 일시불
+			04/10 13:15
+			코레일유통서울지사
+			누적 560,852원
+			0.7%할인`),
+      ).toEqual({
+        cardname: '현대',
+        amount: 2500,
+        date: '04/10',
+        time: '13:15',
+        transactionType: '승인',
+        isDeposit: false,
+      });
+    });
+  });
+});
+
+describe('----------신한----------', () => {
+  describe('Case 1. 승인', () => {
+    test('카드명: 신한체크\n', () => {
+      expect(
+        parsingTextContent(`[Web발신]
+				[신한체크승인] 홍*동(1234)
+				02/10 13:10
+				(금액)1,000원 PAYCO`),
+      ).toEqual({
+        cardname: '신한',
+        amount: 1000,
+        date: '02/10',
+        time: '13:10',
+        transactionType: '승인',
+        isDeposit: false,
+      });
+    });
   });
 
-  expect(
-    parsingTextContent(`롯데3121 승인
-  5,200원 일시불
-  09/15 18:31
-  월드크리닝 롯데마트`),
-  ).toEqual({
-    cardname: '롯데',
-    amount: 5200,
-    date: '09/15',
-    time: '18:31',
-    transactionType: '승인',
-    isDeposit: false,
+  describe('Case 2. 출금', () => {
+    test('카드명: 신한은행\n', () => {
+      expect(
+        parsingTextContent(`[Web발신]
+				[신한은행] 09/26
+				21:31:30.27
+				[123-***-123456]
+				지급 20,000원
+				(홍길동)`),
+      ).toEqual({
+        cardname: '신한',
+        amount: 20000,
+        date: '09/26',
+        time: '21:31',
+        transactionType: '승인',
+        isDeposit: false,
+      });
+    });
   });
+});
 
-  expect(
-    parsingTextContent(`[Web발신]
-  우리(4575)승인취소
-  임*봉님
-  4562원 일시불
-  12/07 20:29
-  네이버페이
-  누적123,456원`),
-  ).toEqual({
-    cardname: '우리',
-    amount: 4562,
-    date: '12/07',
-    time: '20:29',
-    transactionType: '취소',
-    isDeposit: true,
-  });
-
-  expect(
-    parsingTextContent(`[Web발신]
-  우리(8804) 체크승인
-  윤*우님
-  10,000원
-  11/03 10:03
-  스타벅스코리아`),
-  ).toEqual({
-    cardname: '우리',
-    amount: 10000,
-    date: '11/03',
-    time: '10:03',
-    transactionType: '승인',
-    isDeposit: false,
-  });
-
-  expect(
-    parsingTextContent(`[Web발신]
-  KB국민체크
-  윤*우님
-  06/08 08:57
-  28,440원
-  11PAY 인증
-  승인취소
-  `),
-  ).toEqual({
-    cardname: 'KB',
-    amount: 28440,
-    date: '06/08',
-    time: '08:57',
-    transactionType: '취소',
-    isDeposit: true,
+describe('----------롯데----------', () => {
+  describe('Case 1. 승인', () => {
+    test('카드명: 롯데\n', () => {
+      expect(
+        parsingTextContent(`롯데1234 승인
+			5,200원 일시불
+			09/15 18:31
+			월드크리닝 롯데마트`),
+      ).toEqual({
+        cardname: '롯데',
+        amount: 5200,
+        date: '09/15',
+        time: '18:31',
+        transactionType: '승인',
+        isDeposit: false,
+      });
+    });
   });
 });

--- a/server/src/__test__/services/sms-parsing.test.js
+++ b/server/src/__test__/services/sms-parsing.test.js
@@ -1,0 +1,139 @@
+const { parsingTextContent } = require('@services/transaction');
+
+test('parsingTextContent', () => {
+  expect(
+    parsingTextContent(`[WEB발신]
+    KB국민카드 김영근님 06/07
+    09:22 5000원
+    결제 승인`),
+  ).toEqual({
+    cardname: 'KB',
+    amount: 5000,
+    date: '06/07',
+    time: '09:22',
+    transactionType: '승인',
+    isDeposit: false,
+  });
+
+  expect(
+    parsingTextContent(`[Web발신]
+    농협 입금 200원
+    06/11 22:29 123-1234-4567-12
+    잔액 200000원`),
+  ).toEqual({
+    cardname: '농협',
+    amount: 200,
+    date: '06/11',
+    time: '22:29',
+    transactionType: '승인',
+    isDeposit: true,
+  });
+
+  expect(
+    parsingTextContent(`농협 출금 5000원
+    08/31 19:01 123-1234-1234-12
+    잔액 200000원`),
+  ).toEqual({
+    cardname: '농협',
+    amount: 5000,
+    date: '08/31',
+    time: '19:01',
+    transactionType: '승인',
+    isDeposit: false,
+  });
+
+  expect(
+    parsingTextContent(`현대 ZERO 승인
+  2,500원 일시불
+  04/10 13:15
+  코레일유통서울지사
+  누적 560,852원
+  0.7%할인`),
+  ).toEqual({
+    cardname: '현대',
+    amount: 2500,
+    date: '04/10',
+    time: '13:15',
+    transactionType: '승인',
+    isDeposit: false,
+  });
+
+  expect(
+    parsingTextContent(`[Web발신]
+    [신한체크승인] 최*희(7062)
+    02/10 13:10
+    (금액)1,000원 PAYCO`),
+  ).toEqual({
+    cardname: '신한',
+    amount: 1000,
+    date: '02/10',
+    time: '13:10',
+    transactionType: '승인',
+    isDeposit: false,
+  });
+
+  expect(
+    parsingTextContent(`롯데3121 승인
+  5,200원 일시불
+  09/15 18:31
+  월드크리닝 롯데마트`),
+  ).toEqual({
+    cardname: '롯데',
+    amount: 5200,
+    date: '09/15',
+    time: '18:31',
+    transactionType: '승인',
+    isDeposit: false,
+  });
+
+  expect(
+    parsingTextContent(`[Web발신]
+  우리(4575)승인취소
+  임*봉님
+  4562원 일시불
+  12/07 20:29
+  네이버페이
+  누적123,456원`),
+  ).toEqual({
+    cardname: '우리',
+    amount: 4562,
+    date: '12/07',
+    time: '20:29',
+    transactionType: '취소',
+    isDeposit: true,
+  });
+
+  expect(
+    parsingTextContent(`[Web발신]
+  우리(8804) 체크승인
+  윤*우님
+  10,000원
+  11/03 10:03
+  스타벅스코리아`),
+  ).toEqual({
+    cardname: '우리',
+    amount: 10000,
+    date: '11/03',
+    time: '10:03',
+    transactionType: '승인',
+    isDeposit: false,
+  });
+
+  expect(
+    parsingTextContent(`[Web발신]
+  KB국민체크
+  윤*우님
+  06/08 08:57
+  28,440원
+  11PAY 인증
+  승인취소
+  `),
+  ).toEqual({
+    cardname: 'KB',
+    amount: 28440,
+    date: '06/08',
+    time: '08:57',
+    transactionType: '취소',
+    isDeposit: true,
+  });
+});

--- a/server/src/api/controllers/transaction.js
+++ b/server/src/api/controllers/transaction.js
@@ -48,13 +48,13 @@ const deleteExpenditureTransaction = async (ctx) => {
 };
 
 const parsingTextContent = async (ctx) => {
-  const textContent = ctx.request.body;
-  if (!textContent) {
+  const { text } = ctx.request.body;
+  if (!text) {
     const error = new Error('문자 내역이 존재하지 않습니다.');
     error.status = 400;
     throw error;
   }
-  const result = await transactionService.parsingTextContent(textContent);
+  const result = await transactionService.parsingTextContent(text);
   if (result.transactionType === '거절') {
     const error = new Error('승인 거절된 거래 내역은 가계부의 거래 내역으로 등록할 수 없습니다.');
     error.status = 400;

--- a/server/src/api/controllers/transaction.js
+++ b/server/src/api/controllers/transaction.js
@@ -47,6 +47,22 @@ const deleteExpenditureTransaction = async (ctx) => {
   ctx.status = 204;
 };
 
+const parsingTextContent = async (ctx) => {
+  const textContent = ctx.request.body;
+  if (!textContent) {
+    const error = new Error('문자 내역이 존재하지 않습니다.');
+    error.status = 400;
+    throw error;
+  }
+  const result = await transactionService.parsingTextContent(textContent);
+  if (result.transactionType === '거절') {
+    const error = new Error('승인 거절된 거래 내역은 가계부의 거래 내역으로 등록할 수 없습니다.');
+    error.status = 400;
+    throw error;
+  }
+  ctx.body = result;
+};
+
 module.exports = {
   findTransactions,
   createIncomeTransaction,
@@ -55,4 +71,5 @@ module.exports = {
   updateExpenditureTransaction,
   deleteIncomeTransaction,
   deleteExpenditureTransaction,
+  parsingTextContent,
 };

--- a/server/src/api/controllers/transaction.js
+++ b/server/src/api/controllers/transaction.js
@@ -47,14 +47,14 @@ const deleteExpenditureTransaction = async (ctx) => {
   ctx.status = 204;
 };
 
-const parsingTextContent = async (ctx) => {
+const parsingTextContent = (ctx) => {
   const { text } = ctx.request.body;
   if (!text) {
     const error = new Error('문자 내역이 존재하지 않습니다.');
     error.status = 400;
     throw error;
   }
-  const result = await transactionService.parsingTextContent(text);
+  const result = transactionService.parsingTextContent(text);
   if (result.transactionType === '거절') {
     const error = new Error('승인 거절된 거래 내역은 가계부의 거래 내역으로 등록할 수 없습니다.');
     error.status = 400;

--- a/server/src/api/routes/transaction.js
+++ b/server/src/api/routes/transaction.js
@@ -11,5 +11,6 @@ router.patch('/income/:income_id', isAccountbookUser, transactionController.upda
 router.patch('/expenditure/:expenditure_id', isAccountbookUser, transactionController.updateExpenditureTransaction);
 router.delete('/income/:income_id', isAccountbookUser, transactionController.deleteIncomeTransaction);
 router.delete('/expenditure/:expenditure_id', isAccountbookUser, transactionController.deleteExpenditureTransaction);
+router.post('text-parsing', isAccountbookUser, transactionController.parsingTextContent);
 
 module.exports = router;

--- a/server/src/api/routes/transaction.js
+++ b/server/src/api/routes/transaction.js
@@ -11,6 +11,6 @@ router.patch('/income/:income_id', isAccountbookUser, transactionController.upda
 router.patch('/expenditure/:expenditure_id', isAccountbookUser, transactionController.updateExpenditureTransaction);
 router.delete('/income/:income_id', isAccountbookUser, transactionController.deleteIncomeTransaction);
 router.delete('/expenditure/:expenditure_id', isAccountbookUser, transactionController.deleteExpenditureTransaction);
-router.post('text-parsing', isAccountbookUser, transactionController.parsingTextContent);
+router.post('/text-parsing', transactionController.parsingTextContent);
 
 module.exports = router;

--- a/server/src/services/transaction.js
+++ b/server/src/services/transaction.js
@@ -207,7 +207,7 @@ const parsingTextContent = (text) => {
       result.cardname = cardName;
     }
     if (token.includes('원') && !result.amount) {
-      result.amount = Number(token.match(/[0-9]+(,?[0-9]+)+/)[0].replace(',', ''));
+      result.amount = Number(token.match(/[0-9]+(,?[0-9]+)+/)[0].replace(/,/g, ''));
       return;
     }
     if (token.includes(':')) {

--- a/server/src/services/transaction.js
+++ b/server/src/services/transaction.js
@@ -181,9 +181,7 @@ const deleteExpenditureById = async (id) => {
   await db.expenditure.destroy({ where: { id } });
 };
 
-const parsingTextContent = async (text) => {
-  console.log(text);
-  console.log(typeof text);
+const parsingTextContent = (text) => {
   const textTokenization = (string) => {
     return string
       .replace(/\[web발신\]/i, '')


### PR DESCRIPTION
## 관련 이슈
close #261 [가계부 내역 페이지] 결제내역 SMS/MMS 파싱 API 구현

## 구현/수정 내용
- 결제내역 SMS/MMS 파싱하는 함수를 구현했습니다.
- 결제내역 SMS/MMS 파싱하는 함수에 대해 테스트 파일을 생성했습니다.
- API 문서화했습니다.

## 참고
아직 완벽하지는 않은 것 같습니다. 함수를 구현한 후 테스트케이스를 계속 조정해보며, 아래와 같이 쉼표 두 개 이상이 등장하는 금액이 나올 때 처리하지 못한 걸 처리했습니다. 리팩토링 기간에 여유가 된다면 테스트 케이스를 더 수집하여 성능을 향상시켜도 좋을 것 같습니다.

- 실패한 테스트케이스
![](https://i.imgur.com/1r2kjFr.png)

- replace가 한 번 이루어지기 때문에 발생했던 문제였습니다.
![](https://i.imgur.com/ZoLpGu8.png)

- replace 함수의 첫번째 인자를 정규식으로 주어 문제를 해결했습니다.
![](https://i.imgur.com/ZIDTmnS.png)
![](https://i.imgur.com/S2rZzlF.png)

@boostcamp-2020/accountbook_mentor 