### PR TITLE
사이드바에 있는 가계부에 hover했을 때 가계부 설명 출력되는 기능 추가

### DIFF
--- a/client/src/components/common/small-accountbook-item/SmallAccountbookItem.tsx
+++ b/client/src/components/common/small-accountbook-item/SmallAccountbookItem.tsx
@@ -26,7 +26,6 @@ const AccountbookNameWrapper = styled.div`
   position: absolute;
   left: 100%;
   background-color: ${GRAY};
-  min-width: 160px;
   box-shadow: 0px 4px 8px 0px;
   z-index: 1;
 `;

--- a/client/src/components/common/small-accountbook-item/SmallAccountbookItem.tsx
+++ b/client/src/components/common/small-accountbook-item/SmallAccountbookItem.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
 import { getTextColor } from '../../../utils/color';
+import { GRAY, LIGHT_GRAY } from '../../../constants/color';
 
 interface SmallAccountbookItemWrapperProps {
   bgColor: string;
@@ -8,6 +9,27 @@ interface SmallAccountbookItemWrapperProps {
   textColor: string;
   onClick?: () => void;
 }
+
+const AccountbookName = styled.div`
+  color: black;
+  padding: 10px 14px;
+  display: block;
+
+  &:hover {
+    background-color: ${LIGHT_GRAY};
+    cursor: pointer;
+  }
+`;
+
+const AccountbookNameWrapper = styled.div`
+  display: none;
+  position: absolute;
+  left: 100%;
+  background-color: ${GRAY};
+  min-width: 160px;
+  box-shadow: 0px 4px 8px 0px;
+  z-index: 1;
+`;
 
 const SmallAccountbookItemWrapper = styled.div<SmallAccountbookItemWrapperProps>`
   display: flex;
@@ -36,6 +58,10 @@ const SmallAccountbookItemWrapper = styled.div<SmallAccountbookItemWrapperProps>
   .text {
     text-align: center;
   }
+
+  &:hover ${AccountbookNameWrapper} {
+    display: block;
+  }
 `;
 
 interface SmallAccountbookItemProps {
@@ -50,6 +76,9 @@ const SmallAccountbookItem = ({ id, bgColor, show, onClick }: SmallAccountbookIt
   return (
     <SmallAccountbookItemWrapper bgColor={bgColor} textColor={textColor} show={show} onClick={onClick}>
       <div className="text">{id}</div>
+      <AccountbookNameWrapper>
+        <AccountbookName>가계부 이름</AccountbookName>
+      </AccountbookNameWrapper>
     </SmallAccountbookItemWrapper>
   );
 };

--- a/client/src/components/common/small-accountbook-item/SmallAccountbookItem.tsx
+++ b/client/src/components/common/small-accountbook-item/SmallAccountbookItem.tsx
@@ -50,10 +50,10 @@ const SmallAccountbookItemWrapper = styled.div<SmallAccountbookItemWrapperProps>
   overflow: hidden;
   text-overflow: ellipsis;
   margin: 20px auto;
-  transition: all ease 0.3s 0s;
+  transition: all ease 0.1s 0s;
 
   &:hover {
-    border: ${({ textColor }) => textColor} 3px solid;
+    border: ${({ textColor }) => textColor} 2px solid;
     cursor: pointer;
   }
 

--- a/client/src/components/common/small-accountbook-item/SmallAccountbookItem.tsx
+++ b/client/src/components/common/small-accountbook-item/SmallAccountbookItem.tsx
@@ -29,12 +29,10 @@ const SmallAccountbookItemWrapper = styled.div<SmallAccountbookItemWrapperProps>
   transition: all ease 0.3s 0s;
 
   &:hover {
-    border: white 2px solid;
-    width: 50px;
-    height: 50px;
-    font-size: 1.9em;
+    border: ${({ textColor }) => textColor} 3px solid;
     cursor: pointer;
   }
+
   .text {
     text-align: center;
   }

--- a/client/src/components/common/small-accountbook-item/SmallAccountbookItem.tsx
+++ b/client/src/components/common/small-accountbook-item/SmallAccountbookItem.tsx
@@ -21,14 +21,15 @@ const AccountbookName = styled.div`
   }
 `;
 
-const AccountbookNameWrapper = styled.div`
+const AccountbookNameWrapper = styled.div<{ bgColor: string }>`
   display: none;
   position: absolute;
   left: 115%;
-  background-color: ${GRAY};
+  background-color: ${({ bgColor }) => bgColor};
   box-shadow: 2px 3px 7px gray;
   z-index: 1;
   border-radius: 5px;
+  height: 10vh;
 `;
 
 const SmallAccountbookItemWrapper = styled.div<SmallAccountbookItemWrapperProps>`
@@ -78,8 +79,9 @@ const SmallAccountbookItem = ({ id, bgColor, show, onClick }: SmallAccountbookIt
   return (
     <SmallAccountbookItemWrapper bgColor={bgColor} textColor={textColor} show={show} onClick={onClick}>
       <div className="text">{id}</div>
-      <AccountbookNameWrapper>
-        <AccountbookName>가계부 이름</AccountbookName>
+      <AccountbookNameWrapper bgColor={bgColor}>
+        <AccountbookName>가계부 {id}</AccountbookName>
+        <AccountbookName>가계부 {id}에 대한 설명입니다.</AccountbookName>
       </AccountbookNameWrapper>
     </SmallAccountbookItemWrapper>
   );

--- a/client/src/components/common/small-accountbook-item/SmallAccountbookItem.tsx
+++ b/client/src/components/common/small-accountbook-item/SmallAccountbookItem.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
 import { getTextColor } from '../../../utils/color';
-import { GRAY, LIGHT_GRAY } from '../../../constants/color';
+import { LIGHT_GRAY } from '../../../constants/color';
 
 interface SmallAccountbookItemWrapperProps {
   bgColor: string;
@@ -10,10 +10,22 @@ interface SmallAccountbookItemWrapperProps {
   onClick?: () => void;
 }
 
-const AccountbookName = styled.div`
-  color: black;
+const AccountbookName = styled.div<{ textColor: string }>`
+  color: ${({ textColor }) => textColor};
   padding: 10px 14px;
   display: block;
+
+  &:hover {
+    background-color: ${LIGHT_GRAY};
+    cursor: pointer;
+  }
+`;
+
+const AccountbookDescription = styled.div<{ textColor: string }>`
+  color: ${({ textColor }) => textColor};
+  padding: 10px 14px;
+  display: block;
+  font-size: 0.8em;
 
   &:hover {
     background-color: ${LIGHT_GRAY};
@@ -29,7 +41,6 @@ const AccountbookNameWrapper = styled.div<{ bgColor: string }>`
   box-shadow: 2px 3px 7px gray;
   z-index: 1;
   border-radius: 5px;
-  height: 10vh;
 `;
 
 const SmallAccountbookItemWrapper = styled.div<SmallAccountbookItemWrapperProps>`
@@ -80,8 +91,8 @@ const SmallAccountbookItem = ({ id, bgColor, show, onClick }: SmallAccountbookIt
     <SmallAccountbookItemWrapper bgColor={bgColor} textColor={textColor} show={show} onClick={onClick}>
       <div className="text">{id}</div>
       <AccountbookNameWrapper bgColor={bgColor}>
-        <AccountbookName>가계부 {id}</AccountbookName>
-        <AccountbookName>가계부 {id}에 대한 설명입니다.</AccountbookName>
+        <AccountbookName textColor={textColor}>가계부 {id}</AccountbookName>
+        <AccountbookDescription textColor={textColor}>가계부 {id}에 대한 설명입니다.</AccountbookDescription>
       </AccountbookNameWrapper>
     </SmallAccountbookItemWrapper>
   );

--- a/client/src/components/common/small-accountbook-item/SmallAccountbookItem.tsx
+++ b/client/src/components/common/small-accountbook-item/SmallAccountbookItem.tsx
@@ -61,6 +61,8 @@ const SmallAccountbookItemWrapper = styled.div<SmallAccountbookItemWrapperProps>
 
   &:hover ${AccountbookNameWrapper} {
     display: block;
+    font-size: 0.8em;
+    font-weight: 400;
   }
 `;
 

--- a/client/src/components/common/small-accountbook-item/SmallAccountbookItem.tsx
+++ b/client/src/components/common/small-accountbook-item/SmallAccountbookItem.tsx
@@ -24,10 +24,11 @@ const AccountbookName = styled.div`
 const AccountbookNameWrapper = styled.div`
   display: none;
   position: absolute;
-  left: 100%;
+  left: 115%;
   background-color: ${GRAY};
-  box-shadow: 0px 4px 8px 0px;
+  box-shadow: 2px 3px 7px gray;
   z-index: 1;
+  border-radius: 5px;
 `;
 
 const SmallAccountbookItemWrapper = styled.div<SmallAccountbookItemWrapperProps>`

--- a/client/src/components/common/small-accountbook-item/SmallAccountbookItem.tsx
+++ b/client/src/components/common/small-accountbook-item/SmallAccountbookItem.tsx
@@ -14,11 +14,6 @@ const AccountbookName = styled.div<{ textColor: string }>`
   color: ${({ textColor }) => textColor};
   padding: 10px 14px;
   display: block;
-
-  &:hover {
-    background-color: ${LIGHT_GRAY};
-    cursor: pointer;
-  }
 `;
 
 const AccountbookDescription = styled.div<{ textColor: string }>`
@@ -26,14 +21,9 @@ const AccountbookDescription = styled.div<{ textColor: string }>`
   padding: 10px 14px;
   display: block;
   font-size: 0.8em;
-
-  &:hover {
-    background-color: ${LIGHT_GRAY};
-    cursor: pointer;
-  }
 `;
 
-const AccountbookNameWrapper = styled.div<{ bgColor: string }>`
+const AccountbookViewWrapper = styled.div<{ bgColor: string }>`
   display: none;
   position: absolute;
   left: 115%;
@@ -71,7 +61,7 @@ const SmallAccountbookItemWrapper = styled.div<SmallAccountbookItemWrapperProps>
     text-align: center;
   }
 
-  &:hover ${AccountbookNameWrapper} {
+  &:hover ${AccountbookViewWrapper} {
     display: block;
     font-size: 0.8em;
     font-weight: 400;
@@ -90,10 +80,10 @@ const SmallAccountbookItem = ({ id, bgColor, show, onClick }: SmallAccountbookIt
   return (
     <SmallAccountbookItemWrapper bgColor={bgColor} textColor={textColor} show={show} onClick={onClick}>
       <div className="text">{id}</div>
-      <AccountbookNameWrapper bgColor={bgColor}>
+      <AccountbookViewWrapper bgColor={bgColor}>
         <AccountbookName textColor={textColor}>가계부 {id}</AccountbookName>
         <AccountbookDescription textColor={textColor}>가계부 {id}에 대한 설명입니다.</AccountbookDescription>
-      </AccountbookNameWrapper>
+      </AccountbookViewWrapper>
     </SmallAccountbookItemWrapper>
   );
 };


### PR DESCRIPTION
## 관련 이슈
close #265 [가계부 내역 페이지] 사이드바에 있는 가계부에 hover했을 때 가계부 설명 출력 
<br>

## 구현 세부사항
- 사이드바에 있는 가계부에 hover했을 때 가계부 관련 정보 출력
    - 출력창에는 해당하는 가계부 색상의 출력창이 출력된다.
    - 출력창에는 해당하는 가계부 이름과 가계부 설명이 출력된다.
- 사이드바에 있는 가계부에 hover했을 때의 간단한 style 변경
<br>


## 시각 자료
![화면-기록-2020-12-13-오후-5 10 24](https://user-images.githubusercontent.com/42263086/102006689-5d86b580-3d66-11eb-95df-52ae3c014cec.gif)


<br>

## 기타사항
- 가계부 선택 페이지 구현이 완료되면 사이드바에 유저가 가지고 있는 가계부가 출력되도록 해야 한다.
    - 클릭했을 때 해당 가계부의 내역 페이지로 이동하는 로직 추가 필요
    - hover했을 때 해당 가계부의 이름, 설명이 연동되는 로직 추가 필요

<br>


@boostcamp-2020/accountbook_mentor 


