### PR TITLE
cors 80번 포트일 때 문제 생겼던 부분 처리

### DIFF
--- a/server/src/app.js
+++ b/server/src/app.js
@@ -10,7 +10,8 @@ const startServer = async () => {
   const app = new Koa();
   const port = serverConfig.serverPort || 3000;
   const httpServer = http.createServer(app.callback());
-  const io = socketIO(httpServer, { cors: { origin: `${clientHost}:${clientPort}`, credentials: true } });
+  const origin = `${clientHost}${clientPort === '80' ? '' : `:${clientPort}`}`;
+  const io = socketIO(httpServer, { cors: { origin, credentials: true } });
 
   connectOn(io);
   await server(app);

--- a/server/src/loaders/koa.js
+++ b/server/src/loaders/koa.js
@@ -18,10 +18,11 @@ const errorHandler = async (ctx, next) => {
   }
 };
 
+const origin = `${clientHost}${clientPort === '80' ? '' : `:${clientPort}`}`;
 const koa = async (app) => {
   app.use(
     cors({
-      origin: `${clientHost}:${clientPort}`,
+      origin,
       credentials: true,
     }),
   );


### PR DESCRIPTION
cors의 origin에서 사용하는 client port가 80번일 경우 아예 기재해주지 않아야 정상적으로 동작하는 것을 확인했습니다.

hotfix로 머지하겠습니다. 