### PR TITLE
카테고리 생성, 결제수단 생성 API 수정

### DIFF
--- a/server/src/api/controllers/category.js
+++ b/server/src/api/controllers/category.js
@@ -36,6 +36,7 @@ const updateIncomeCategory = async (ctx) => {
   const { income_category_id: incomeCategoryId } = ctx.request.params;
   const incomeCategoryData = ctx.request.body;
   const updatedIncomeCategory = await categoryService.updateIncomeCategory(incomeCategoryId, incomeCategoryData);
+  console.log(updatedIncomeCategory.toJSON());
   ctx.body = updatedIncomeCategory;
 };
 

--- a/server/src/api/controllers/category.js
+++ b/server/src/api/controllers/category.js
@@ -36,7 +36,6 @@ const updateIncomeCategory = async (ctx) => {
   const { income_category_id: incomeCategoryId } = ctx.request.params;
   const incomeCategoryData = ctx.request.body;
   const updatedIncomeCategory = await categoryService.updateIncomeCategory(incomeCategoryId, incomeCategoryData);
-  console.log(updatedIncomeCategory.toJSON());
   ctx.body = updatedIncomeCategory;
 };
 

--- a/server/src/services/account.js
+++ b/server/src/services/account.js
@@ -32,7 +32,8 @@ const createAccount = async ({ accountbookId, name, color }) => {
     name,
     color,
   });
-  return createdAccount;
+  const account = await findAccountById(createdAccount.toJSON().id);
+  return account;
 };
 
 const updateAccount = async (accountId, { name, color }) => {

--- a/server/src/services/category.js
+++ b/server/src/services/category.js
@@ -50,7 +50,8 @@ const createIncomeCategory = async ({ accountbookId, name, color }) => {
     name,
     color,
   });
-  return createdIncomeCategory;
+  const incomeCategory = await findIncomeCategoryById(createdIncomeCategory.toJSON().id);
+  return incomeCategory;
 };
 
 const createExpenditureCategory = async ({ accountbookId, name, color }) => {

--- a/server/src/services/category.js
+++ b/server/src/services/category.js
@@ -67,7 +67,8 @@ const createExpenditureCategory = async ({ accountbookId, name, color }) => {
     name,
     color,
   });
-  return createdExpenditureCategory;
+  const expenditureCategory = await findExpenditureCategoryById(createdExpenditureCategory.id);
+  return expenditureCategory;
 };
 
 const updateIncomeCategory = async (incomeCategoryId, { name, color }) => {


### PR DESCRIPTION
## 구현/수정 내용
- API Docs를 정리하는 과정에서 카테고리 생성, 결제수단 생성 API의 응답이 created_at과 updated_at을 포함하는 것을 발견하여 이 부분을  id, name, color 속성만 보내주도록 수정하였습니다.

@boostcamp-2020/accountbook_mentor 