### PR TITLE
가계부 생성 API 구현

### DIFF
--- a/server/src/api/controllers/accountbook.js
+++ b/server/src/api/controllers/accountbook.js
@@ -9,10 +9,10 @@ const getAccountbooksByUserId = async (ctx) => {
 };
 
 const createAccountbook = async (ctx) => {
-  const { title, description, color } = ctx.request.body;
+  const accountbookData = ctx.request.body;
   const token = ctx.cookies.get('jwt');
-  const decoded = decodeToken(token);
-  const createdAccountbook = await accountbookService.createAccountbook(decoded.userId, title, description, color);
+  accountbookData.userId = decodeToken(token).userId;
+  const createdAccountbook = await accountbookService.createAccountbook(accountbookData);
   ctx.body = createdAccountbook;
 };
 

--- a/server/src/api/controllers/accountbook.js
+++ b/server/src/api/controllers/accountbook.js
@@ -8,6 +8,14 @@ const getAccountbooksByUserId = async (ctx) => {
   ctx.body = accountbooks;
 };
 
+const createAccountbook = async (ctx) => {
+  const { title, description, color } = ctx.request.body;
+  const token = ctx.cookies.get('jwt');
+  const decoded = decodeToken(token);
+  const createdAccountbook = await accountbookService.createAccountbook(decoded.userId, title, description, color);
+  ctx.body = createdAccountbook;
+};
+
 const deleteAccountbook = async (ctx) => {
   const token = ctx.cookies.get('jwt');
   const { accountbook_id: accountbookId } = ctx.params;
@@ -18,5 +26,6 @@ const deleteAccountbook = async (ctx) => {
 
 module.exports = {
   getAccountbooksByUserId,
+  createAccountbook,
   deleteAccountbook,
 };

--- a/server/src/api/routes/accountbook.js
+++ b/server/src/api/routes/accountbook.js
@@ -6,7 +6,7 @@ const { isAccountbookUser } = require('@middlewares/accountbookAuth');
 const router = new Router();
 
 router.get('/', verificationOfAuth, accountbookController.getAccountbooksByUserId);
-router.post('/', isAccountbookUser, accountbookController.createAccountbook);
+router.post('/', verificationOfAuth, accountbookController.createAccountbook);
 router.delete('/:accountbook_id', isAccountbookUser, accountbookController.deleteAccountbook);
 
 module.exports = router;

--- a/server/src/api/routes/accountbook.js
+++ b/server/src/api/routes/accountbook.js
@@ -6,6 +6,7 @@ const { isAccountbookUser } = require('@middlewares/accountbookAuth');
 const router = new Router();
 
 router.get('/', verificationOfAuth, accountbookController.getAccountbooksByUserId);
+router.post('/', isAccountbookUser, accountbookController.createAccountbook);
 router.delete('/:accountbook_id', isAccountbookUser, accountbookController.deleteAccountbook);
 
 module.exports = router;

--- a/server/src/services/accountbook.js
+++ b/server/src/services/accountbook.js
@@ -14,6 +14,23 @@ const getAccountbookById = async (id) => {
   return accountbook;
 };
 
+const getAccountbookByUserAccountbookId = async (id) => {
+  const accountbook = await db.userAccountbook.findOne({
+    where: {
+      id,
+    },
+    attributes: ['id', 'authority', 'description', 'color', 'accountbookId'],
+    include: [
+      {
+        model: db.accountbook,
+        attributes: ['title'],
+      },
+    ],
+    raw: true,
+  });
+  return accountbook;
+};
+
 const getAccountbooksByUserId = async (userId) => {
   const accountbooks = await db.userAccountbook.findAll({
     where: {
@@ -31,6 +48,21 @@ const getAccountbooksByUserId = async (userId) => {
   return accountbooks;
 };
 
+const createAccountbook = async ({ userId, title, description, color }) => {
+  const newAccountbook = await db.accountbook.create({
+    title,
+  });
+  const newUserAccountbook = await db.userAccountbook.create({
+    description,
+    color,
+    userId,
+    accountbookId: newAccountbook.toJSON().id,
+    authority: true,
+  });
+  const createdAccountbook = await getAccountbookByUserAccountbookId(newUserAccountbook.toJSON().id);
+  return createdAccountbook;
+};
+
 const deleteAccountbook = async (accountbookId, userId) => {
   await db.userAccountbook.destroy({ where: { accountbookId, userId } });
   const userAccountbooks = await db.userAccountbook.findAll({ where: { accountbookId } });
@@ -43,4 +75,5 @@ module.exports = {
   getAccountbookById,
   getAccountbooksByUserId,
   deleteAccountbook,
+  createAccountbook,
 };


### PR DESCRIPTION
## 관련 이슈
close #291 가계부 생성 API 구현

## 구현 세부사항
- 가계부 생성 API 만들었습니다.
    - 유저가 가계부 생성 시 accountbook 테이블에 가계부를 만든 후, userAccountbook 테이블에서 해당 유저와 새로 만든 테이블의 관계 레코드 하나를 만듭니다.
    - 반환은 accountbook 테이블의 title까지 포함합니다.

@boostcamp-2020/accountbook_mentor 