### PR TITLE
카테고리, 결제수단 중복검사 로직 버그 수정

### DIFF
--- a/client/src/components/common/modals/form-modal-account/FormModalUpdateAccount.tsx
+++ b/client/src/components/common/modals/form-modal-account/FormModalUpdateAccount.tsx
@@ -24,6 +24,7 @@ const FormModalUpdateAccount: React.FC = () => {
   const id = useGetParam();
   const updateAccountFormStore = rootStore.modalStore.updateAccountFormStore;
   const { show } = updateAccountFormStore;
+  const [colorCheck, setColorCheck] = useState(false);
   const [name, setName] = useState<string>((updateAccountFormStore.account as Account).name);
   const [inputColor, setInputColor] = useState<string>((updateAccountFormStore.account as Account).color);
   const { check, noChange } = rootStore.modalStore.updateAccountFormStore;
@@ -50,6 +51,11 @@ const FormModalUpdateAccount: React.FC = () => {
 
   const onChange = (color: { hex: string }): void => {
     setInputColor(color.hex);
+    if (inputColor.toLowerCase() === (updateAccountFormStore.account as Account).color.toLowerCase()) {
+      setColorCheck(false);
+    } else {
+      setColorCheck(true);
+    }
   };
 
   const modalToggle = (): void => {
@@ -85,8 +91,8 @@ const FormModalUpdateAccount: React.FC = () => {
     return (
       <ModalBackground show={show} closeModal={modalToggle}>
         <FormModalWrapper>
-          {check ? (
-            name && !noChange ? (
+          {check || noChange ? (
+            (name && !noChange) || (name && colorCheck) ? (
               <FormModalHeader
                 modalName={formModal.UPDATE_ACCOUNT_MODAL_NAME}
                 blueName={'완료'}

--- a/client/src/components/common/modals/form-modal-category/FormModalUpdateCategory.tsx
+++ b/client/src/components/common/modals/form-modal-category/FormModalUpdateCategory.tsx
@@ -25,6 +25,7 @@ const FormModalUpdateCategory: React.FC = () => {
   const updateCategoryFormStore = rootStore.modalStore.updateCategoryFormStore;
   const { show } = updateCategoryFormStore;
   const { check, noChange } = rootStore.modalStore.updateCategoryFormStore;
+  const [colorCheck, setColorCheck] = useState(false);
 
   const [name, setName] = useState<string>(
     updateCategoryFormStore.incomeFlag
@@ -61,7 +62,9 @@ const FormModalUpdateCategory: React.FC = () => {
       } else {
         updateCategoryFormStore.setNoChangeFalse();
       }
-    } else {
+    }
+
+    if (!updateCategoryFormStore.incomeFlag) {
       if (rootStore.categoryStore.expenditureCategoryNames.includes(e.target.value)) {
         updateCategoryFormStore.setCheckFalse();
       } else {
@@ -77,6 +80,21 @@ const FormModalUpdateCategory: React.FC = () => {
 
   const onChange = (color: { hex: string }): void => {
     setInputColor(color.hex);
+    if (updateCategoryFormStore.incomeFlag) {
+      if (inputColor === (updateCategoryFormStore.incomeCategory as Category).color) {
+        setColorCheck(false);
+      } else {
+        setColorCheck(true);
+      }
+    }
+
+    if (!updateCategoryFormStore.incomeFlag) {
+      if (inputColor === (updateCategoryFormStore.expenditureCategory as Category).color) {
+        setColorCheck(false);
+      } else {
+        setColorCheck(true);
+      }
+    }
   };
 
   const modalToggle = (): void => {
@@ -127,8 +145,8 @@ const FormModalUpdateCategory: React.FC = () => {
   return (
     <ModalBackground show={show} closeModal={modalToggle}>
       <FormModalWrapper>
-        {check ? (
-          name && !noChange ? (
+        {check || noChange ? (
+          (name && !noChange) || (name && colorCheck) ? (
             <FormModalHeader
               modalName={
                 updateCategoryFormStore.incomeFlag

--- a/client/src/components/common/modals/form-modal-category/FormModalUpdateCategory.tsx
+++ b/client/src/components/common/modals/form-modal-category/FormModalUpdateCategory.tsx
@@ -81,7 +81,7 @@ const FormModalUpdateCategory: React.FC = () => {
   const onChange = (color: { hex: string }): void => {
     setInputColor(color.hex);
     if (updateCategoryFormStore.incomeFlag) {
-      if (inputColor === (updateCategoryFormStore.incomeCategory as Category).color) {
+      if (inputColor.toLowerCase() === (updateCategoryFormStore.incomeCategory as Category).color.toLowerCase()) {
         setColorCheck(false);
       } else {
         setColorCheck(true);
@@ -89,7 +89,7 @@ const FormModalUpdateCategory: React.FC = () => {
     }
 
     if (!updateCategoryFormStore.incomeFlag) {
-      if (inputColor === (updateCategoryFormStore.expenditureCategory as Category).color) {
+      if (inputColor.toLowerCase() === (updateCategoryFormStore.expenditureCategory as Category).color.toLowerCase()) {
         setColorCheck(false);
       } else {
         setColorCheck(true);

--- a/server/src/services/account.js
+++ b/server/src/services/account.js
@@ -41,7 +41,7 @@ const updateAccount = async (accountId, { name, color }) => {
   const duplicatedAccount = await db.account.findOne({
     where: { accountbookId: currentAccount.toJSON().accountbookId, name },
   });
-  if (duplicatedAccount) {
+  if (duplicatedAccount && duplicatedAccount.toJSON().color.toLowerCase() === color.toLowerCase()) {
     throw new Error('이미 존재하는 결제수단입니다.');
   }
 

--- a/server/src/services/category.js
+++ b/server/src/services/category.js
@@ -76,7 +76,7 @@ const updateIncomeCategory = async (incomeCategoryId, { name, color }) => {
   const duplicateCategory = await db.incomeCategory.findOne({
     where: { accountbookId: currentCategory.toJSON().accountbookId, name },
   });
-  if (duplicateCategory) {
+  if (duplicateCategory && duplicateCategory.toJSON().color === color) {
     throw new Error('이미 존재하는 카테고리 입니다.');
   }
 
@@ -98,7 +98,7 @@ const updateExpenditureCategory = async (expenditureCategoryId, { name, color })
   const duplicateCategory = await db.expenditureCategory.findOne({
     where: { accountbookId: currentCategory.toJSON().accountbookId, name },
   });
-  if (duplicateCategory) {
+  if (duplicateCategory && duplicateCategory.toJSON().color === color) {
     throw new Error('이미 존재하는 카테고리 입니다.');
   }
 

--- a/server/src/services/category.js
+++ b/server/src/services/category.js
@@ -76,7 +76,7 @@ const updateIncomeCategory = async (incomeCategoryId, { name, color }) => {
   const duplicateCategory = await db.incomeCategory.findOne({
     where: { accountbookId: currentCategory.toJSON().accountbookId, name },
   });
-  if (duplicateCategory && duplicateCategory.toJSON().color === color) {
+  if (duplicateCategory && duplicateCategory.toJSON().color.toLowerCase() === color.toLowerCase()) {
     throw new Error('이미 존재하는 카테고리 입니다.');
   }
 
@@ -98,7 +98,7 @@ const updateExpenditureCategory = async (expenditureCategoryId, { name, color })
   const duplicateCategory = await db.expenditureCategory.findOne({
     where: { accountbookId: currentCategory.toJSON().accountbookId, name },
   });
-  if (duplicateCategory && duplicateCategory.toJSON().color === color) {
+  if (duplicateCategory && duplicateCategory.toJSON().color.toLowerCase() === color.toLowerCase()) {
     throw new Error('이미 존재하는 카테고리 입니다.');
   }
 


### PR DESCRIPTION
## 관련 이슈
close #283 [가계부 설정 페이지] 카테고리, 결제수단 중복검사 로직 버그 수정

## 구현/수정 내용
- color만 바뀐 경우에도 완료 버튼이 활성화 되도록 수정하였습니다.
- 백엔드에서도 이름과 컬러가 모두 같은 경우에만 중복 되었다고 판단하도록 로직을 수정하였습니다.

@boostcamp-2020/accountbook_mentor 