### PR TITLE
feat : 카테고리 파이그래프 표기를 5개에서 8개로 변경

### DIFF
--- a/client/src/components/graph/line-chart/lineChartUtils.ts
+++ b/client/src/components/graph/line-chart/lineChartUtils.ts
@@ -86,9 +86,9 @@ const immutableTransaction = (transactions: ITransaction[]): ITransaction[] => {
 
 export const gatherByDate = (transactions: ITransaction[]): ITransaction[] => {
   const ans: ITransaction[] = [];
-  const map = new Map<number, number>();
+  const map = new Map<string, number>();
   transactions.forEach((transaction) => {
-    const timeValue = transaction.date.valueOf();
+    const timeValue = transaction.date.toDateString();
     if (!map.has(timeValue)) {
       map.set(timeValue, transaction.value);
     } else {

--- a/client/src/store/PieGraphPageStore.tsx
+++ b/client/src/store/PieGraphPageStore.tsx
@@ -6,7 +6,7 @@ import { action, makeObservable, observable, computed, flow } from 'mobx';
 import datePeriod, { datePeriodNumber } from '../constants/datePeriod';
 import transactionService from '../services/transaction';
 import PieChartValue from '../types/pieChartValue';
-import { getOnlyIncome, getTopFiveCategory, getOnlyExpenditure } from '../utils/filter';
+import { getOnlyIncome, getTopEightCategory, getOnlyExpenditure } from '../utils/filter';
 import BoxChartValue from '../types/boxChartValue';
 import { CancellablePromise } from 'mobx/dist/api/flow';
 import getSWRGenerator from '../utils/generator/getSWRGenerator';
@@ -154,7 +154,7 @@ export default class PieGraphPageStore {
       ? getOnlyIncome(this.transactions)
       : getOnlyExpenditure(this.transactions);
 
-    const topOfFive = getTopFiveCategory(targetTransactions);
+    const topOfFive = getTopEightCategory(targetTransactions);
     return topOfFive;
   }
 
@@ -164,7 +164,7 @@ export default class PieGraphPageStore {
       ? getOnlyIncome(this.transactions)
       : getOnlyExpenditure(this.transactions);
 
-    const topOfFive = getTopFiveCategory(targetTransactions);
+    const topOfFive = getTopEightCategory(targetTransactions);
     return topOfFive;
   }
 

--- a/client/src/utils/filter.ts
+++ b/client/src/utils/filter.ts
@@ -125,7 +125,7 @@ const getCategoryList = (
   return [memorized, totalValue];
 };
 
-const getTopOfFiveList = (
+const getTopOfEight = (
   categoryList: ICategoryValue[],
   totalValue: number,
 ): [topOfFive: BoxChartValue[], remain: BoxChartValue[]] => {
@@ -143,10 +143,10 @@ const getTopOfFiveList = (
     return 0;
   });
 
-  return [categoryListWithRatio.slice(0, 5), categoryListWithRatio.slice(5)];
+  return [categoryListWithRatio.slice(0, 8), categoryListWithRatio.slice(8)];
 };
 
-export function getTopFiveCategory(transactions: Array<Income | Expenditure>): BoxChartValue[] {
+export function getTopEightCategory(transactions: Array<Income | Expenditure>): BoxChartValue[] {
   const [memorized, totalValue] = getCategoryList(transactions);
   if (totalValue === 0) {
     return [];
@@ -154,10 +154,10 @@ export function getTopFiveCategory(transactions: Array<Income | Expenditure>): B
 
   const categoryList = Array.from(memorized).map(([name, value]) => value);
 
-  const [topOfFive, remain] = getTopOfFiveList(categoryList, totalValue);
+  const [topOfEight, remain] = getTopOfEight(categoryList, totalValue);
 
-  if (categoryList.length > 5) {
-    const endOfFive = topOfFive[4];
+  if (categoryList.length > 8) {
+    const endOfFive = topOfEight[4];
     endOfFive.title = '기타';
 
     remain.forEach((transaction) => {
@@ -167,7 +167,7 @@ export function getTopFiveCategory(transactions: Array<Income | Expenditure>): B
     endOfFive.ratio = (endOfFive.value * 100) / totalValue;
   }
 
-  topOfFive.sort(function (transactionPrev: BoxChartValue, transactionNext: BoxChartValue) {
+  topOfEight.sort(function (transactionPrev: BoxChartValue, transactionNext: BoxChartValue) {
     if (transactionPrev.ratio > transactionNext.ratio) {
       return -1;
     }
@@ -177,5 +177,5 @@ export function getTopFiveCategory(transactions: Array<Income | Expenditure>): B
     return 1;
   });
 
-  return topOfFive;
+  return topOfEight;
 }


### PR DESCRIPTION
파이그래프 표시가 5개에서 8개로 증가했습니다.

## 구현 세부사항
![화면 캡처 2020-12-15 110825](https://user-images.githubusercontent.com/49854357/102162069-dbb09c80-3ecb-11eb-9c7c-15b6456ec9bf.png)

@boostcamp-2020/accountbook_mentor 