### PR TITLE
가계부 내역 페이지에 무한스크롤 적용

### DIFF
--- a/client/src/components/common/sidebar/Sidebar.tsx
+++ b/client/src/components/common/sidebar/Sidebar.tsx
@@ -2,16 +2,11 @@ import React, { useState, memo, useEffect } from 'react';
 import styled from 'styled-components';
 import HomeButton from '../home-button/HomeButton';
 import HamburgerButton from '../hamburger-button/HamburgerButton';
-import PlusButton from '../plus-button/PlusButton';
 import SmallAccountbookItem from '../small-accountbook-item/SmallAccountbookItem';
 import { GRAY } from '../../../constants/color';
 import { useHistory } from 'react-router-dom';
 import useStore from '../../../hook/use-store/useStore';
 import { Link } from 'react-router-dom';
-
-interface SidebarProps {
-  smallAccountbooks: { id: number; color: string }[];
-}
 
 interface SidebarWrapperProps {
   show: boolean;
@@ -85,7 +80,6 @@ const Sidebar = (): JSX.Element => {
         <ChildrenWrapper>
           <HomeButton show={isOpen} onClick={() => history.push(`/`)} />
           {SmallAccountbooks}
-          <PlusButton show={isOpen} />
         </ChildrenWrapper>
       </SidebarWrapper>
     </div>

--- a/client/src/components/common/transactions/all-transaction-container/AllTransactionContainer.tsx
+++ b/client/src/components/common/transactions/all-transaction-container/AllTransactionContainer.tsx
@@ -18,10 +18,6 @@ const calcSameDateTransactions = (transactions: Array<Income | Expenditure>): Ar
   let beforeMonth = 0;
   let beforeDay = 0;
 
-  transactions = transactions.slice().sort((transaction1, transaction2) => {
-    return new Date(transaction2.date).getTime() - new Date(transaction1.date).getTime();
-  });
-
   transactions.forEach((transaction) => {
     const currentDate = new Date(transaction.date);
     const currentYear = currentDate.getFullYear();

--- a/client/src/components/common/transactions/day-transaction-container/DayTransactionContainer.tsx
+++ b/client/src/components/common/transactions/day-transaction-container/DayTransactionContainer.tsx
@@ -49,9 +49,24 @@ const DayTransactionContainer = ({ transactions }: Props): JSX.Element => {
   const month = new Date(transactions[0].date).getMonth() + 1;
   const date = new Date(transactions[0].date).getDate();
   const day = days[new Date(transactions[0].date).getDay()];
-  const totalAmount = transactions.reduce((sum, transaction) => {
+  let totalAmount = transactions.reduce((sum, transaction) => {
     return isIncome(transaction) ? sum + transaction.amount : sum - transaction.amount;
   }, 0);
+
+  for (let i = transactionStore.items; i < transactionStore.transactions.length; i++) {
+    if (
+      new Date(transactions[0].date).getMonth() == new Date(transactionStore.transactions[i].date).getMonth() &&
+      new Date(transactions[0].date).getDate() == new Date(transactionStore.transactions[i].date).getDate()
+    ) {
+      if (isIncome(transactionStore.transactions[i])) {
+        totalAmount += transactionStore.transactions[i].amount;
+      } else {
+        totalAmount -= transactionStore.transactions[i].amount;
+      }
+    } else {
+      break;
+    }
+  }
 
   return (
     <Container>

--- a/client/src/pages/transaction-page/TransactionView.tsx
+++ b/client/src/pages/transaction-page/TransactionView.tsx
@@ -17,6 +17,7 @@ import FormModalCreateTransaction from '../../components/common/modals/form-moda
 import FormModalUpdateTransaction from '../../components/common/modals/form-modal-transaction/FormModalUpdateTransaction';
 import HeaderNavigationRightTopWrapper from '../../components/common/header-navigation/HeaderNavigationRightTop';
 import socket, { event } from '../../socket';
+import { sortByRecentDate } from '../../utils/sortByRecentDate';
 
 const ViewWrapper = styled.div`
   width: 70%;
@@ -144,7 +145,9 @@ const TransactionView: React.FC<Props> = ({ accountbookId, query }: Props) => {
             <Amount text={'지출'} amount={totalExpenditure} />
           </AmountWrapper>
         </TransactionHeaderWrapper>
-        <AllTransactionContainer transactions={transactionStore.transactions} />
+        <AllTransactionContainer
+          transactions={sortByRecentDate(transactionStore.transactions).slice(0, transactionStore.items)}
+        />
       </ViewWrapper>
     </>
   );

--- a/client/src/pages/transaction-page/TransactionView.tsx
+++ b/client/src/pages/transaction-page/TransactionView.tsx
@@ -112,6 +112,21 @@ const TransactionView: React.FC<Props> = ({ accountbookId, query }: Props) => {
     updateTransactions();
   }, [query, accountbookId]);
 
+  useEffect(() => {
+    window.addEventListener('scroll', infiniteScroll);
+    return () => window.removeEventListener('scroll', infiniteScroll);
+  }, []);
+
+  const infiniteScroll = () => {
+    const scrollHeight = Math.max(document.documentElement.scrollHeight, document.body.scrollHeight);
+    const scrollTop = Math.max(document.documentElement.scrollTop, document.body.scrollTop);
+    const clientHeight = document.documentElement.clientHeight;
+    if (scrollTop + clientHeight >= scrollHeight) {
+      transactionStore.prevItems = transactionStore.items;
+      transactionStore.items += 10;
+    }
+  };
+
   return (
     <>
       {filterFormStore.show && <FormModalFilter accountbookId={accountbookId} />}

--- a/client/src/store/TransactionStore.tsx
+++ b/client/src/store/TransactionStore.tsx
@@ -21,6 +21,12 @@ export default class TransactionStore {
   isLoading = true;
 
   @observable
+  prevItems = 0;
+
+  @observable
+  items = 20;
+
+  @observable
   csvTransactions: Array<CsvTransaction> = [];
 
   rootStore: RootStore;

--- a/client/src/utils/sortByRecentDate.ts
+++ b/client/src/utils/sortByRecentDate.ts
@@ -1,0 +1,7 @@
+import { Income } from '../types/income';
+import { Expenditure } from '../types/expenditure';
+
+export const sortByRecentDate = (transactions: Array<Income | Expenditure>): Array<Income | Expenditure> =>
+  transactions.slice().sort((transaction1, transaction2) => {
+    return new Date(transaction2.date).getTime() - new Date(transaction1.date).getTime();
+  });


### PR DESCRIPTION
## 관련 이슈
close #330 [가계부 내역 페이지] 무한스크롤 적용 
<br>

## 구현 세부사항
- 가계부 내역 페이지에 무한 스크롤 적용
<br>


## 무한스크롤 동작 모습
![화면-기록-2020-12-16-오전-3 45 12](https://user-images.githubusercontent.com/42263086/102260600-03e3de00-3f54-11eb-8e6c-bee720187005.gif)

<br>

## 기타사항
- 모든 거래내역이 렌더링되고 스크롤을 위로 올렸다가 다시 내렸을 때 계속 items가 증가하는 부분 수정 필요 => 오류는 없으나 불필요한 이벤트 발생 최소화
- 무한스크롤 최적화를 위해 디바운싱 혹은 쓰로틀링 적용 필요 => 일정 시간동안 같은 이벤트(scroll)가 발생하지 않도록 해주는 기능
<br>


@boostcamp-2020/accountbook_mentor 


