### PR TITLE
hotfix: 무한스크롤 버그 수정

### DIFF
--- a/client/src/pages/transaction-page/TransactionView.tsx
+++ b/client/src/pages/transaction-page/TransactionView.tsx
@@ -66,7 +66,6 @@ const TransactionView: React.FC<Props> = ({ accountbookId, query }: Props) => {
 
   const updateTransactions = () => {
     if (!query) {
-      transactionStore.isFilterMode = false;
       transactionStore.findTransactions(accountbookId, dateStore.startDate, dateStore.endDate);
       return;
     }
@@ -117,11 +116,15 @@ const TransactionView: React.FC<Props> = ({ accountbookId, query }: Props) => {
     return () => window.removeEventListener('scroll', infiniteScroll);
   }, []);
 
+  useEffect(() => {
+    transactionStore.items = 20;
+  }, [query, accountbookId, dateStore.startDate]);
+
   const infiniteScroll = () => {
     const scrollHeight = Math.max(document.documentElement.scrollHeight, document.body.scrollHeight);
     const scrollTop = Math.max(document.documentElement.scrollTop, document.body.scrollTop);
     const clientHeight = document.documentElement.clientHeight;
-    if (scrollTop + clientHeight >= scrollHeight) {
+    if (scrollTop + clientHeight + 1 >= scrollHeight) {
       transactionStore.prevItems = transactionStore.items;
       transactionStore.items += 10;
     }

--- a/client/src/pages/transaction-page/TransactionView.tsx
+++ b/client/src/pages/transaction-page/TransactionView.tsx
@@ -125,7 +125,6 @@ const TransactionView: React.FC<Props> = ({ accountbookId, query }: Props) => {
     const scrollTop = Math.max(document.documentElement.scrollTop, document.body.scrollTop);
     const clientHeight = document.documentElement.clientHeight;
     if (scrollTop + clientHeight + 1 >= scrollHeight) {
-      transactionStore.prevItems = transactionStore.items;
       transactionStore.items += 10;
     }
   };

--- a/client/src/store/TransactionStore.tsx
+++ b/client/src/store/TransactionStore.tsx
@@ -20,9 +20,6 @@ export default class TransactionStore {
   isLoading = true;
 
   @observable
-  prevItems = 0;
-
-  @observable
   items = 20;
 
   @observable


### PR DESCRIPTION
## 구현/수정 내용
- 스크롤이 제일아래에 있더라도 scrollTop + clientHeight < scrollHeight 인 경우가 있어서 +1 을 해줘서 너무 민감하게 반응하지 않도록 하였습니다.

- items가 20개 이상  쌓였을 때 달을 변경하거나 필터링을 하면 items가 그대로
20개 이상으로 유지되어 20개만 렌더링하는게 아니라 items 만큼 렌더링하는
오류를 수정하였습니다.