### PR TITLE
내역의 개수 표시, 각종 버그 수정, 코드 리팩토링 

### DIFF
--- a/client/src/components/common/category/Category.tsx
+++ b/client/src/components/common/category/Category.tsx
@@ -29,7 +29,7 @@ export const CategoryWrapper = styled.div<{
   overflow: hidden;
   text-overflow: ellipsis;
   pointer-events: ${({ preview }) => preview};
-
+  cursor: pointer;
   &:hover {
     box-shadow: ${({ shadow }) => (shadow === true ? '2px 3px 7px gray' : 0)};
   }

--- a/client/src/components/common/transactions/all-transaction-container/AllTransactionContainer.tsx
+++ b/client/src/components/common/transactions/all-transaction-container/AllTransactionContainer.tsx
@@ -7,7 +7,6 @@ import Spinner from '../../spinner/Spinner';
 import useStore from '../../../../hook/use-store/useStore';
 import { observer } from 'mobx-react';
 import styled from 'styled-components';
-
 interface Props {
   transactions: Array<Income | Expenditure>;
 }

--- a/client/src/components/common/transactions/all-transaction-container/AllTransactionContainer.tsx
+++ b/client/src/components/common/transactions/all-transaction-container/AllTransactionContainer.tsx
@@ -7,6 +7,7 @@ import Spinner from '../../spinner/Spinner';
 import useStore from '../../../../hook/use-store/useStore';
 import { observer } from 'mobx-react';
 import styled from 'styled-components';
+import { RED } from '../../../../constants/color';
 interface Props {
   transactions: Array<Income | Expenditure>;
 }
@@ -16,7 +17,7 @@ const Count = styled.div`
   margin-bottom: 5px;
   color: grey;
   .number {
-    color: red;
+    color: ${RED};
   }
 `;
 
@@ -62,7 +63,9 @@ const AllTransactionContainer = ({ transactions }: Props): JSX.Element => {
 
   return (
     <>
-      <Count>총 [ {transactionStore.transactions.length} ]개</Count>
+      <Count>
+        [총 <span className="number">{transactionStore.transactions.length}</span>개]
+      </Count>
       {sameDateTransactions.map((transactions) => {
         return (
           <div key={isIncome(transactions[0]) ? `income${transactions[0].id}` : `expenditure${transactions[0].id}`}>

--- a/client/src/components/common/transactions/all-transaction-container/AllTransactionContainer.tsx
+++ b/client/src/components/common/transactions/all-transaction-container/AllTransactionContainer.tsx
@@ -53,7 +53,7 @@ const AllTransactionContainer = ({ transactions }: Props): JSX.Element => {
 
   useEffect(() => {
     return () => {
-      transactionStore.isLoading = true;
+      transactionStore.setIsLoading(true);
     };
   }, []);
 

--- a/client/src/components/common/transactions/all-transaction-container/AllTransactionContainer.tsx
+++ b/client/src/components/common/transactions/all-transaction-container/AllTransactionContainer.tsx
@@ -6,10 +6,20 @@ import NotFoundTransaction from '../../not-found-transaction/NotFoundTransaction
 import Spinner from '../../spinner/Spinner';
 import useStore from '../../../../hook/use-store/useStore';
 import { observer } from 'mobx-react';
+import styled from 'styled-components';
 
 interface Props {
   transactions: Array<Income | Expenditure>;
 }
+
+const Count = styled.div`
+  padding-left: 4px;
+  margin-bottom: 5px;
+  color: grey;
+  .number {
+    color: red;
+  }
+`;
 
 const calcSameDateTransactions = (transactions: Array<Income | Expenditure>): Array<Array<Income | Expenditure>> => {
   const sameDateTransactions = [] as Array<Array<Income | Expenditure>>;
@@ -53,6 +63,7 @@ const AllTransactionContainer = ({ transactions }: Props): JSX.Element => {
 
   return (
     <>
+      <Count>총 [ {transactionStore.transactions.length} ]개</Count>
       {sameDateTransactions.map((transactions) => {
         return (
           <div key={isIncome(transactions[0]) ? `income${transactions[0].id}` : `expenditure${transactions[0].id}`}>

--- a/client/src/components/common/transactions/day-transaction-container/DayTransactionContainer.tsx
+++ b/client/src/components/common/transactions/day-transaction-container/DayTransactionContainer.tsx
@@ -6,6 +6,7 @@ import { numberWithCommas } from '../../../../utils/number';
 import { RED, BLUE, GRAY } from '../../../../constants/color';
 import TransactionItem from '../transaction-item/TransactionItem';
 import useStore from '../../../../hook/use-store/useStore';
+import { sortByRecentDate } from '../../../../utils/sortByRecentDate';
 
 const Container = styled.div`
   display: flex;
@@ -53,16 +54,15 @@ const DayTransactionContainer = ({ transactions }: Props): JSX.Element => {
     return isIncome(transaction) ? sum + transaction.amount : sum - transaction.amount;
   }, 0);
 
+  // 스크롤 아래에 있는 보이지않는 내역 데이터들의 amount 계산
+  const AllTransactions = transactionStore.sortedTransactions.slice();
   for (let i = transactionStore.items; i < transactionStore.transactions.length; i++) {
-    if (
-      new Date(transactions[0].date).getMonth() == new Date(transactionStore.transactions[i].date).getMonth() &&
-      new Date(transactions[0].date).getDate() == new Date(transactionStore.transactions[i].date).getDate()
-    ) {
-      if (isIncome(transactionStore.transactions[i])) {
-        totalAmount += transactionStore.transactions[i].amount;
-      } else {
-        totalAmount -= transactionStore.transactions[i].amount;
-      }
+    const nextItem = AllTransactions[i];
+    const currentItemDate = new Date(transactions[0].date);
+    const nextItemDate = new Date(AllTransactions[i].date);
+
+    if (currentItemDate.getMonth() == nextItemDate.getMonth() && currentItemDate.getDate() == nextItemDate.getDate()) {
+      totalAmount = totalAmount + (isIncome(nextItem) ? nextItem.amount : -nextItem.amount);
     } else {
       break;
     }

--- a/client/src/components/common/transactions/day-transaction-container/DayTransactionContainer.tsx
+++ b/client/src/components/common/transactions/day-transaction-container/DayTransactionContainer.tsx
@@ -6,7 +6,6 @@ import { numberWithCommas } from '../../../../utils/number';
 import { RED, BLUE, GRAY } from '../../../../constants/color';
 import TransactionItem from '../transaction-item/TransactionItem';
 import useStore from '../../../../hook/use-store/useStore';
-import { sortByRecentDate } from '../../../../utils/sortByRecentDate';
 
 const Container = styled.div`
   display: flex;

--- a/client/src/components/transaction-page/filter-option/FilterOption.tsx
+++ b/client/src/components/transaction-page/filter-option/FilterOption.tsx
@@ -4,6 +4,7 @@ import CancelButton from './CancelButton';
 import Query from '../../../types/query';
 import { getFormattedDate } from '../../../utils/date';
 import { useHistory } from 'react-router-dom';
+import useStore from '../../../hook/use-store/useStore';
 
 const Wrapper = styled.div`
   display: flex;
@@ -50,10 +51,12 @@ const getOptionText = (account: string, incomeCategory: string, expenditureCateg
 };
 
 const FilterOption: React.FC<Props> = ({ query, accountbookId }: Props) => {
+  const { transactionStore } = useStore().rootStore;
   const { startDate, endDate, account, incomeCategory, expenditureCategory } = query;
   const history = useHistory();
 
   const onClickCancel = () => {
+    transactionStore.isFilterMode = false;
     history.push(`/accountbooks/${accountbookId}`);
   };
 

--- a/client/src/pages/settings-accountbook-page/SettingsAccountbookPage.tsx
+++ b/client/src/pages/settings-accountbook-page/SettingsAccountbookPage.tsx
@@ -70,11 +70,11 @@ const SettingsAccountbookPage: React.FC = () => {
       setTitle((accountbookStore.accountbook as Accountbook).title);
       setDescription((accountbookStore.accountbook as Accountbook).description);
       setInputColor((accountbookStore.accountbook as Accountbook).color);
-      accountbookStore.isLoading = false;
+      accountbookStore.setIsLoading(false);
     };
     loadAccountbooks();
     return () => {
-      accountbookStore.isLoading = true;
+      accountbookStore.setIsLoading(true);
     };
   }, []);
 

--- a/client/src/pages/settings-accounts-page/SettingsAccountsView.tsx
+++ b/client/src/pages/settings-accounts-page/SettingsAccountsView.tsx
@@ -52,9 +52,9 @@ const SettingsAccountsView: React.FC<Props> = ({ accountbookId }: Props) => {
 
   useEffect(() => {
     accountStore.updateAccounts(accountbookId);
-    accountStore.isLoading = false;
+    accountStore.setIsLoading(false);
     return () => {
-      accountStore.isLoading = true;
+      accountStore.setIsLoading(true);
     };
   }, []);
 

--- a/client/src/pages/settings-categories-page/SettingsCategoriesView.tsx
+++ b/client/src/pages/settings-categories-page/SettingsCategoriesView.tsx
@@ -54,9 +54,9 @@ const SettingsCategoriesView: React.FC<Props> = ({ accountbookId }: Props) => {
   useEffect(() => {
     categoryStore.updateIncomeCategories(accountbookId);
     categoryStore.updateExpenditureCategories(accountbookId);
-    categoryStore.isLoading = false;
+    categoryStore.setIsLoading(false);
     return () => {
-      categoryStore.isLoading = true;
+      categoryStore.setIsLoading(true);
     };
   }, []);
 

--- a/client/src/pages/settings-social-page/SettingsSocialPage.tsx
+++ b/client/src/pages/settings-social-page/SettingsSocialPage.tsx
@@ -31,8 +31,8 @@ const SettingsSocialPage: React.FC = () => {
   useEffect(() => {
     socialStore.findUsers(accountbookId);
     return () => {
-      socialStore.searchSuccess = null;
-      socialStore.isLoading = true;
+      socialStore.setSearchSuccess(null);
+      socialStore.setIsLoading(true);
     };
   }, []);
 

--- a/client/src/pages/transaction-page/TransactionView.tsx
+++ b/client/src/pages/transaction-page/TransactionView.tsx
@@ -66,6 +66,7 @@ const TransactionView: React.FC<Props> = ({ accountbookId, query }: Props) => {
 
   const updateTransactions = () => {
     if (!query) {
+      transactionStore.setIsFilterMode(false);
       transactionStore.findTransactions(accountbookId, dateStore.startDate, dateStore.endDate);
       return;
     }

--- a/client/src/pages/transaction-page/TransactionView.tsx
+++ b/client/src/pages/transaction-page/TransactionView.tsx
@@ -117,7 +117,7 @@ const TransactionView: React.FC<Props> = ({ accountbookId, query }: Props) => {
   }, []);
 
   useEffect(() => {
-    transactionStore.items = 20;
+    transactionStore.setItems(20);
   }, [query, accountbookId, dateStore.startDate]);
 
   const infiniteScroll = () => {
@@ -125,7 +125,7 @@ const TransactionView: React.FC<Props> = ({ accountbookId, query }: Props) => {
     const scrollTop = Math.max(document.documentElement.scrollTop, document.body.scrollTop);
     const clientHeight = document.documentElement.clientHeight;
     if (scrollTop + clientHeight + 1 >= scrollHeight) {
-      transactionStore.items += 10;
+      transactionStore.setItems(transactionStore.items + 10);
     }
   };
 

--- a/client/src/store/AccountStore.tsx
+++ b/client/src/store/AccountStore.tsx
@@ -98,4 +98,9 @@ export default class AccountStore {
 
     return data;
   }
+
+  @action
+  setIsLoading = (isLoading: boolean): void => {
+    this.isLoading = isLoading;
+  };
 }

--- a/client/src/store/AccountbookStore.tsx
+++ b/client/src/store/AccountbookStore.tsx
@@ -63,4 +63,9 @@ export default class AccountbookStore {
       authority: true,
     });
   };
+
+  @action
+  setIsLoading = (isLoading: boolean): void => {
+    this.isLoading = isLoading;
+  };
 }

--- a/client/src/store/CategoryStore.tsx
+++ b/client/src/store/CategoryStore.tsx
@@ -185,4 +185,9 @@ export default class CategoryStore {
 
     return data;
   }
+
+  @action
+  setIsLoading = (isLoading: boolean): void => {
+    this.isLoading = isLoading;
+  };
 }

--- a/client/src/store/SocialStore.tsx
+++ b/client/src/store/SocialStore.tsx
@@ -90,4 +90,14 @@ export default class DateStore {
       this.rootStore.userStore.changeAuthority(accountbookId, false);
     });
   };
+
+  @action
+  setSearchSuccess = (searchSuccess: boolean | null): void => {
+    this.searchSuccess = searchSuccess;
+  };
+
+  @action
+  setIsLoading = (isLoading: boolean): void => {
+    this.isLoading = isLoading;
+  };
 }

--- a/client/src/store/TransactionStore.tsx
+++ b/client/src/store/TransactionStore.tsx
@@ -215,4 +215,9 @@ export default class TransactionStore {
   setIsLoading = (isLoading: boolean): void => {
     this.isLoading = isLoading;
   };
+
+  @action
+  setIsFilterMode = (isFilterMode: boolean): void => {
+    this.isFilterMode = isFilterMode;
+  };
 }

--- a/client/src/store/TransactionStore.tsx
+++ b/client/src/store/TransactionStore.tsx
@@ -9,9 +9,13 @@ import Query from '../types/query';
 import { CancellablePromise } from 'mobx/dist/api/flow';
 import socket, { event } from '../socket';
 import getSWRGenerator from '../utils/generator/getSWRGenerator';
+import { sortByRecentDate } from '../utils/sortByRecentDate';
 export default class TransactionStore {
   @observable
   transactions: Array<Income | Expenditure> = [];
+
+  @observable
+  sortedTransactions: Array<Income | Expenditure> = [];
 
   @observable
   isFilterMode = false;
@@ -65,10 +69,12 @@ export default class TransactionStore {
     if (cached.value !== undefined) {
       this.isLoading = false;
       this.transactions = cached.value;
+      this.sortedTransactions = sortByRecentDate(this.transactions.slice());
     }
     const refreshedData = yield generation.next();
     this.isLoading = false;
     this.transactions = refreshedData.value;
+    this.sortedTransactions = sortByRecentDate(this.transactions.slice());
   });
 
   filterTransactions = flow(function* (
@@ -85,10 +91,12 @@ export default class TransactionStore {
     if (cached.value !== undefined) {
       this.isLoading = false;
       this.transactions = filtering(cached.value, { account, incomeCategory, expenditureCategory });
+      this.sortedTransactions = sortByRecentDate(this.transactions.slice());
     }
     const refreshedData = yield generation.next();
     this.isLoading = false;
     this.transactions = filtering(refreshedData.value, { account, incomeCategory, expenditureCategory });
+    this.sortedTransactions = sortByRecentDate(this.transactions.slice());
     this.isFilterMode = true;
   });
 

--- a/client/src/store/TransactionStore.tsx
+++ b/client/src/store/TransactionStore.tsx
@@ -205,4 +205,14 @@ export default class TransactionStore {
     this.deleteExpenditureById(expenditure.id);
     this.addNewTransaction(expenditure);
   };
+
+  @action
+  setItems = (items: number): void => {
+    this.items = items;
+  };
+
+  @action
+  setIsLoading = (isLoading: boolean): void => {
+    this.isLoading = isLoading;
+  };
 }

--- a/client/src/store/modal-store/FilterFormStore.tsx
+++ b/client/src/store/modal-store/FilterFormStore.tsx
@@ -2,7 +2,7 @@ import { observable, action, makeObservable, computed } from 'mobx';
 import RootStore from '../RootStore';
 import { dateOptions } from '../../__dummy-data__/store/filterFormStore';
 import datePeriod from '../../constants/datePeriod';
-import { getFormattedDate } from '../../utils/date';
+import { getFormattedDate, getDatePeriod } from '../../utils/date';
 import Options from '../../types/dropdownOptions';
 import { ParsedQuery } from 'query-string';
 
@@ -121,37 +121,7 @@ export default class FilterFormStore {
     this.selectedExpenditureCategories = expenditureCategory.length === 0 ? [] : expenditureCategory.split(' ');
     this.startDate.date = new Date(startDate);
     this.endDate.date = new Date(endDate);
-    const period = this.getDatePeriod(new Date(startDate), new Date(endDate));
+    const period = getDatePeriod(new Date(startDate), new Date(endDate));
     this.onChangeDate(period);
-  };
-
-  getDatePeriod = (startDate: Date, endDate: Date): string => {
-    let tempDate = new Date(startDate);
-    const day = 1000 * 60 * 60 * 24;
-    if (tempDate.setFullYear(tempDate.getFullYear() + 1) + day < endDate.getTime()) {
-      return datePeriod.ALL;
-    }
-
-    tempDate = new Date(startDate);
-    if (tempDate.setMonth(tempDate.getMonth() + 6) + day < endDate.getTime()) {
-      return datePeriod.LAST_ONE_YEAR;
-    }
-
-    tempDate = new Date(startDate);
-    if (tempDate.setMonth(tempDate.getMonth() + 3) + day < endDate.getTime()) {
-      return datePeriod.LAST_SIX_MONTH;
-    }
-
-    tempDate = new Date(startDate);
-    if (tempDate.setMonth(tempDate.getMonth() + 1) + day < endDate.getTime()) {
-      return datePeriod.LAST_THREE_MONTH;
-    }
-
-    tempDate = new Date(startDate);
-    if (tempDate.setDate(tempDate.getDate() + 7) < endDate.getTime()) {
-      return datePeriod.LAST_ONE_MONTH;
-    }
-
-    return datePeriod.LAST_ONE_WEEK;
   };
 }

--- a/client/src/utils/date.ts
+++ b/client/src/utils/date.ts
@@ -1,3 +1,4 @@
+import datePeriod from '../constants/datePeriod';
 /*
 TODO :
 윤년인지 판단해주는 함수
@@ -91,4 +92,68 @@ export const getFormattedDate = ({ date, format }: { date: Date; format: string 
   const month = String(date.getMonth() + 1).padStart(2, '0');
   const day = String(date.getDate()).padStart(2, '0');
   return `${year}${format}${month}${format}${day}`;
+};
+
+export const getDatePeriod = (startDate: Date, endDate: Date): string => {
+  if (isAllPeriod(startDate, endDate)) {
+    return datePeriod.ALL;
+  }
+
+  if (isLastOneYear(startDate, endDate)) {
+    return datePeriod.LAST_ONE_YEAR;
+  }
+
+  if (isLastOneSixMonth(startDate, endDate)) {
+    return datePeriod.LAST_SIX_MONTH;
+  }
+
+  if (isLastThreeMonth(startDate, endDate)) {
+    return datePeriod.LAST_THREE_MONTH;
+  }
+
+  if (isLastOneMonth(startDate, endDate)) {
+    return datePeriod.LAST_ONE_MONTH;
+  }
+
+  return datePeriod.LAST_ONE_WEEK;
+};
+
+export const isAllPeriod = (startDate: Date, endDate: Date): boolean => {
+  const tempDate = new Date(startDate);
+  if (tempDate.setFullYear(tempDate.getFullYear() + 1) + 1000 * 60 * 60 * 24 < endDate.getTime()) {
+    return true;
+  }
+  return false;
+};
+
+export const isLastOneYear = (startDate: Date, endDate: Date): boolean => {
+  const tempDate = new Date(startDate);
+  if (tempDate.setMonth(tempDate.getMonth() + 6) + 1000 * 60 * 60 * 24 < endDate.getTime()) {
+    return true;
+  }
+  return false;
+};
+
+export const isLastOneSixMonth = (startDate: Date, endDate: Date): boolean => {
+  const tempDate = new Date(startDate);
+  if (tempDate.setMonth(tempDate.getMonth() + 3) + 1000 * 60 * 60 * 24 < endDate.getTime()) {
+    return true;
+  }
+  return false;
+};
+
+export const isLastThreeMonth = (startDate: Date, endDate: Date): boolean => {
+  const tempDate = new Date(startDate);
+  if (tempDate.setMonth(tempDate.getMonth() + 1) + 1000 * 60 * 60 * 24 < endDate.getTime()) {
+    return true;
+  }
+  return false;
+};
+
+export const isLastOneMonth = (startDate: Date, endDate: Date): boolean => {
+  const tempDate = new Date(startDate);
+  if (tempDate.setDate(tempDate.getDate() + 7) < endDate.getTime()) {
+    return true;
+  }
+  return false;
 };

--- a/client/src/utils/sortByRecentDate.ts
+++ b/client/src/utils/sortByRecentDate.ts
@@ -1,7 +1,9 @@
 import { Income } from '../types/income';
 import { Expenditure } from '../types/expenditure';
 
-export const sortByRecentDate = (transactions: Array<Income | Expenditure>): Array<Income | Expenditure> =>
-  transactions.slice().sort((transaction1, transaction2) => {
+export const sortByRecentDate = (transactions: Array<Income | Expenditure>): Array<Income | Expenditure> => {
+  const sortedTransactions = transactions.slice().sort((transaction1, transaction2) => {
     return new Date(transaction2.date).getTime() - new Date(transaction1.date).getTime();
   });
+  return sortedTransactions;
+};


### PR DESCRIPTION
## 관련 이슈
#338 콘솔에 나오는 mobx wargings 제거하기

## 구현/수정 내용
- 내역페이지에서 총 내역의 개수 표시
- 상태변화를 action으로 감싸 mobx warning을 제거 (원인불명으로 몇개는 제거 못함)
- 특정 날짜의 총지출과 총수입의 합을 계산하는 로직을 좀 더 깔끔하게 리팩토링
- 필터링부분 로직 좀 더 깔끔하게 리팩토링

## 총 내역의 개수 표시
![image](https://user-images.githubusercontent.com/26829633/102349835-4dc9d400-3fe7-11eb-8664-74c4b0526dc1.png)


@boostcamp-2020/accountbook_mentor 