### PR TITLE
무한스크롤 items 늘어나는 부분 수정 및 거래내역 필터 모달창 버그 수정

### DIFF
--- a/client/src/components/accountbook-social-page/user-item/UserItem.tsx
+++ b/client/src/components/accountbook-social-page/user-item/UserItem.tsx
@@ -27,18 +27,28 @@ const Cell = styled.div`
     margin-right: 1rem;
   }
   &:nth-child(2) {
+    padding-top: 0.4rem;
+
     width: 45%;
   }
   &:nth-child(3) {
+    padding-top: 0.4rem;
+
     width: 12%;
   }
   &:nth-child(4) {
+    padding-top: 0.4rem;
+
     width: 25%;
   }
   &:nth-child(5) {
+    padding-top: 0.4rem;
+
     width: 6%;
   }
   &:nth-child(6) {
+    padding-top: 0.4rem;
+
     width: 6%;
   }
 `;

--- a/client/src/components/common/header-navigation/HeaderNavigation.tsx
+++ b/client/src/components/common/header-navigation/HeaderNavigation.tsx
@@ -7,14 +7,18 @@ import useGetParam from '../../../hook/use-get-param/useGetParam';
 
 const NavigationWrapper = styled.div`
   display: flex;
-  width: 200px;
+  align-items: center;
+  top: 2%;
+  width: 190px;
+  margin-right: -20px;
 `;
 
 const NavigationItem = styled.div<{ currentPage: string }>`
-  width: 24%;
-  padding-top: 4px;
+  width: 34%;
   text-align: center;
   font-family: 'Spoqa Han Sans';
+  font-size: 1.2rem;
+  margin-right: 15px;
   &:nth-child(1) a {
     color: ${({ currentPage }) => (currentPage == 'transaction' ? BLUE : 'black')};
     font-weight: ${({ currentPage }) => (currentPage == 'transaction' ? 'bold' : 'normal')};
@@ -22,9 +26,10 @@ const NavigationItem = styled.div<{ currentPage: string }>`
   &:nth-child(2) a {
     color: ${({ currentPage }) => (currentPage == 'statistics' ? BLUE : 'black')};
     font-weight: ${({ currentPage }) => (currentPage == 'statistics' ? 'bold' : 'normal')};
+    margin-right: 12px;
   }
   &:nth-child(3) a {
-    width: 28%;
+    width: 40%;
     display: flex;
     flex-direction: row-reverse;
     padding: 0;

--- a/client/src/components/common/modals/form-modal-filter/FormModalFilter.tsx
+++ b/client/src/components/common/modals/form-modal-filter/FormModalFilter.tsx
@@ -32,7 +32,7 @@ const FormModalFilter = ({ accountbookId }: { accountbookId: number }): JSX.Elem
 
   return (
     <>
-      <ModalBackground show={true} closeModal={closeModal} position="absolute">
+      <ModalBackground show={true} closeModal={closeModal}>
         <FormModalWrapper>
           <FormModalHeader
             modalName={'필터'}

--- a/client/src/components/common/modals/give-admin-modal/UserItemWithRadio.tsx
+++ b/client/src/components/common/modals/give-admin-modal/UserItemWithRadio.tsx
@@ -22,19 +22,24 @@ const Cell = styled.div`
   }
   &:nth-child(2) {
     width: 45%;
+    padding-top: 0.6rem;
   }
   &:nth-child(3) {
     width: 27%;
     text-align: center;
+    padding-top: 0.6rem;
   }
   &:nth-child(4) {
     width: 10%;
+    padding-top: 0.6rem;
   }
   &:nth-child(5) {
     width: 6%;
+    padding-top: 0.6rem;
   }
   &:nth-child(6) {
     width: 6%;
+    padding-top: 0.6rem;
   }
 `;
 

--- a/client/src/components/common/profile-dropdown/ProfileDropdown.tsx
+++ b/client/src/components/common/profile-dropdown/ProfileDropdown.tsx
@@ -30,6 +30,7 @@ const DropdownWrapper = styled.div`
 const ProfileDropdownWrapper = styled.div`
   position: relative;
   display: inline-block;
+  padding-top: 5px;
 
   &:hover ${DropdownWrapper} {
     display: block;

--- a/client/src/components/common/profile-image/ProfileImage.tsx
+++ b/client/src/components/common/profile-image/ProfileImage.tsx
@@ -2,9 +2,9 @@ import React from 'react';
 import styled from 'styled-components';
 
 const Image = styled.img`
-  width: 30px;
-  height: 30px;
-  border-radius: 15px;
+  width: 40px;
+  height: 40px;
+  border-radius: 20px;
   cursor: pointer;
 `;
 

--- a/client/src/pages/transaction-page/TransactionView.tsx
+++ b/client/src/pages/transaction-page/TransactionView.tsx
@@ -18,6 +18,7 @@ import FormModalUpdateTransaction from '../../components/common/modals/form-moda
 import HeaderNavigationRightTopWrapper from '../../components/common/header-navigation/HeaderNavigationRightTop';
 import socket, { event } from '../../socket';
 import { sortByRecentDate } from '../../utils/sortByRecentDate';
+import _ from 'lodash';
 
 const ViewWrapper = styled.div`
   width: 70%;
@@ -121,11 +122,16 @@ const TransactionView: React.FC<Props> = ({ accountbookId, query }: Props) => {
   }, [query, accountbookId, dateStore.startDate]);
 
   const infiniteScroll = () => {
-    const scrollHeight = Math.max(document.documentElement.scrollHeight, document.body.scrollHeight);
     const scrollTop = Math.max(document.documentElement.scrollTop, document.body.scrollTop);
-    const clientHeight = document.documentElement.clientHeight;
-    if (scrollTop + clientHeight + 1 >= scrollHeight) {
-      transactionStore.items += 10;
+    if (scrollTop > transactionStore.lastScrollTop) {
+      // down scroll일 때만 렌더링 여부 검사
+      const scrollHeight = Math.max(document.documentElement.scrollHeight, document.body.scrollHeight);
+      const clientHeight = document.documentElement.clientHeight;
+      if (scrollTop + clientHeight + 1 >= scrollHeight) {
+        transactionStore.items += 10;
+      }
+      transactionStore.lastScrollTop = scrollTop <= 0 ? 0 : scrollTop;
+      console.log(transactionStore.items);
     }
   };
 

--- a/client/src/pages/transaction-page/TransactionView.tsx
+++ b/client/src/pages/transaction-page/TransactionView.tsx
@@ -18,7 +18,6 @@ import FormModalUpdateTransaction from '../../components/common/modals/form-moda
 import HeaderNavigationRightTopWrapper from '../../components/common/header-navigation/HeaderNavigationRightTop';
 import socket, { event } from '../../socket';
 import { sortByRecentDate } from '../../utils/sortByRecentDate';
-import _ from 'lodash';
 
 const ViewWrapper = styled.div`
   width: 70%;

--- a/client/src/store/TransactionStore.tsx
+++ b/client/src/store/TransactionStore.tsx
@@ -23,6 +23,9 @@ export default class TransactionStore {
   items = 20;
 
   @observable
+  lastScrollTop = 0;
+
+  @observable
   csvTransactions: Array<CsvTransaction> = [];
 
   rootStore: RootStore;


### PR DESCRIPTION
## 관련 이슈
#340 [가계부 내역 페이지] 무한스크롤 최적화 작업 
#341 [가계부 내역 페이지] 필터 모달창이 열린 상태에서 스크롤을 따라오지 못하는 오류 해결하기 
<br>

## 구현 세부사항
- 거래내역 페이지의 거래내역들이 모두 렌더링되고 마우스를 스크롤을 올렸다가 다시 페이지 맨 밑에 도착했을 때 items가 계속 증가하는 문제 해결
- 거래내역 필터 모달창이 스크롤을 따라 내려오지 못하는 버그 수정
- ProfileImage 사이즈 확대 및 HeaderNavigation font-size 조절


<br>


## 우측 상단에 프로필 사진 확대된 부분
<img width="1632" alt="스크린샷 2020-12-17 오전 2 36 59" src="https://user-images.githubusercontent.com/42263086/102385071-bed1b180-4010-11eb-8368-c52b18851021.png">

<br>

## 거래내역 필터 모달창 스크롤 따라서 내려오는 부분
<img width="1618" alt="스크린샷 2020-12-17 오전 2 38 09" src="https://user-images.githubusercontent.com/42263086/102385207-e88ad880-4010-11eb-8412-ce57f442bc53.png">


<br>

## 기타사항
- 우리 서비스에는 굳이 디바운싱과 쓰로틀링이 필요하지 않을 것이라고 판단
    - 디바운싱: 반복적으로 호출되는 함수 중 마지막 함수만 호출하는 기법
    - 쓰로틀링: 마지막 함수가 호출된 후 일정 시간이 지나기 전까지 다시 호출되지 않도록 하는 기법
- 무한스크롤 최적화 결론
    - 거래내역이 모두 렌더링되면 scroll eventListener를 삭제하는 방식으로 최적화 (구현 필요)
    - 스크롤을 위로 올렸을 때는 페이지 가장 밑에 도달했는지 검사하는 로직이 실행되지 않도록 조건문 삽입 (구현 완료)
- 필터 모달창을 fixed로 설정하니 드롭다운이 페이지에서 잘려보이는 오류 발생 (해결 필요)
<br>


@boostcamp-2020/accountbook_mentor 


