### PR TITLE
월 바꿨을 때 무한스크롤 동작하지 않는 오류 해결

### DIFF
--- a/client/src/pages/transaction-page/TransactionView.tsx
+++ b/client/src/pages/transaction-page/TransactionView.tsx
@@ -119,6 +119,7 @@ const TransactionView: React.FC<Props> = ({ accountbookId, query }: Props) => {
 
   useEffect(() => {
     transactionStore.setItems(20);
+    transactionStore.setLastScrollTop(0);
   }, [query, accountbookId, dateStore.startDate]);
 
   const infiniteScroll = () => {

--- a/client/src/store/TransactionStore.tsx
+++ b/client/src/store/TransactionStore.tsx
@@ -225,4 +225,9 @@ export default class TransactionStore {
   setIsFilterMode = (isFilterMode: boolean): void => {
     this.isFilterMode = isFilterMode;
   };
+
+  @action
+  setLastScrollTop = (lastScrollTop: number): void => {
+    this.lastScrollTop = lastScrollTop;
+  };
 }


### PR DESCRIPTION
월 바꿨을 때 무한스크롤이 동작하지 않는 오류를 해결하였습니다.
월이 바꼈을 때 lastScrollTop 값을 초기화해주었습니다.