### PR TITLE
라인차트 월변경 오류 수정, 파이차트 기타항목 계산 오류 수정, 중복검사 오류 수정

### DIFF
--- a/client/src/store/LineChartStore.tsx
+++ b/client/src/store/LineChartStore.tsx
@@ -6,6 +6,8 @@ import { getOnlyIncome, getOnlyExpenditure } from '../utils/filter';
 import ITransaction from '../types/lineChartValue';
 import { CancellablePromise } from 'mobx/dist/api/flow';
 import getSWRGenerator from '../utils/generator/getSWRGenerator';
+import { getFirstDateOfNextMonth, getFirstDateOfPreviousMonth } from '../utils/date';
+
 type IncomeExpenditure = Income | Expenditure;
 
 export default class LineChartStore {
@@ -34,19 +36,13 @@ export default class LineChartStore {
 
   @action
   nextMonth = (accountbookId: number): void => {
-    const newDate = new Date();
-    newDate.setDate(1);
-    newDate.setMonth(this.currentDate.getMonth() + 1);
-    this.currentDate = newDate;
+    this.currentDate = getFirstDateOfNextMonth(this.currentDate);
     this.getTransactions(accountbookId);
   };
 
   @action
   prevMonth = (accountbookId: number): void => {
-    const newDate = new Date();
-    newDate.setDate(1);
-    newDate.setMonth(this.currentDate.getMonth() - 1);
-    this.currentDate = newDate;
+    this.currentDate = getFirstDateOfPreviousMonth(this.currentDate);
     this.getTransactions(accountbookId);
   };
 

--- a/client/src/utils/filter.ts
+++ b/client/src/utils/filter.ts
@@ -135,10 +135,13 @@ const getTopOfEight = (
   });
 
   categoryListWithRatio.sort(function (a, b) {
-    if (a.value < b.value) {
+    if (a.value > b.value) {
       return -1;
     }
-    return 0;
+    if (a.value == b.value) {
+      return 0;
+    }
+    return 1;
   });
 
   return [categoryListWithRatio.slice(0, 8), categoryListWithRatio.slice(8)];
@@ -155,14 +158,14 @@ export function getTopEightCategory(transactions: Array<Income | Expenditure>): 
   const [topOfEight, remain] = getTopOfEight(categoryList, totalValue);
 
   if (categoryList.length > 8) {
-    const endOfFive = topOfEight[4];
-    endOfFive.title = '기타';
+    const endOEight = topOfEight[7];
+    endOEight.title = '기타';
 
     remain.forEach((transaction) => {
-      endOfFive.value += transaction.value;
+      endOEight.value += transaction.value;
     });
 
-    endOfFive.ratio = (endOfFive.value * 100) / totalValue;
+    endOEight.ratio = (endOEight.value * 100) / totalValue;
   }
 
   topOfEight.sort(function (transactionPrev: BoxChartValue, transactionNext: BoxChartValue) {

--- a/client/src/utils/form/validation.ts
+++ b/client/src/utils/form/validation.ts
@@ -48,10 +48,6 @@ function normalPass(check, noChange, name, colorCheck) {
     return true;
   }
 
-  // if (name && colorCheck && noChange) {
-  //   return true;
-  // }
-
   if (!check) {
     return false;
   }

--- a/client/src/utils/form/validation.ts
+++ b/client/src/utils/form/validation.ts
@@ -44,9 +44,13 @@ function nothingChange(check: boolean, name: string, noChange: boolean): boolean
 }
 
 function normalPass(check, noChange, name, colorCheck) {
-  if (colorCheck) {
+  if (colorCheck && name && noChange) {
     return true;
   }
+
+  // if (name && colorCheck && noChange) {
+  //   return true;
+  // }
 
   if (!check) {
     return false;

--- a/server/src/services/account.js
+++ b/server/src/services/account.js
@@ -38,11 +38,18 @@ const createAccount = async ({ accountbookId, name, color }) => {
 
 const updateAccount = async (accountId, { name, color }) => {
   const currentAccount = await db.account.findOne({ where: { id: accountId } });
-  const duplicatedAccount = await db.account.findOne({
+  let duplicatedAccount = await db.account.findOne({
     where: { accountbookId: currentAccount.toJSON().accountbookId, name },
   });
-  if (duplicatedAccount && duplicatedAccount.toJSON().color.toLowerCase() === color.toLowerCase()) {
-    throw new Error('이미 존재하는 결제수단입니다.');
+
+  if (duplicatedAccount) {
+    duplicatedAccount = duplicatedAccount.toJSON();
+    if (duplicatedAccount.id === +accountId && duplicatedAccount.color.toLowerCase() === color.toLowerCase()) {
+      throw new Error('이미 존재하는 결제수단입니다.');
+    }
+    if (duplicatedAccount.id !== +accountId) {
+      throw new Error('이미 존재하는 결제수단입니다.');
+    }
   }
 
   await db.account.update(

--- a/server/src/services/category.js
+++ b/server/src/services/category.js
@@ -73,11 +73,18 @@ const createExpenditureCategory = async ({ accountbookId, name, color }) => {
 
 const updateIncomeCategory = async (incomeCategoryId, { name, color }) => {
   const currentCategory = await db.incomeCategory.findOne({ where: { id: incomeCategoryId } });
-  const duplicateCategory = await db.incomeCategory.findOne({
+  let duplicatedCategory = await db.incomeCategory.findOne({
     where: { accountbookId: currentCategory.toJSON().accountbookId, name },
   });
-  if (duplicateCategory && duplicateCategory.toJSON().color.toLowerCase() === color.toLowerCase()) {
-    throw new Error('이미 존재하는 카테고리 입니다.');
+
+  if (duplicatedCategory) {
+    duplicatedCategory = duplicatedCategory.toJSON();
+    if (duplicatedCategory.id === +incomeCategoryId && duplicatedCategory.color.toLowerCase() === color.toLowerCase()) {
+      throw new Error('이미 존재하는 결제수단입니다.');
+    }
+    if (duplicatedCategory.id !== +incomeCategoryId) {
+      throw new Error('이미 존재하는 결제수단입니다.');
+    }
   }
 
   await db.incomeCategory.update(
@@ -95,11 +102,21 @@ const updateIncomeCategory = async (incomeCategoryId, { name, color }) => {
 
 const updateExpenditureCategory = async (expenditureCategoryId, { name, color }) => {
   const currentCategory = await db.expenditureCategory.findOne({ where: { id: expenditureCategoryId } });
-  const duplicateCategory = await db.expenditureCategory.findOne({
+  let duplicatedCategory = await db.expenditureCategory.findOne({
     where: { accountbookId: currentCategory.toJSON().accountbookId, name },
   });
-  if (duplicateCategory && duplicateCategory.toJSON().color.toLowerCase() === color.toLowerCase()) {
-    throw new Error('이미 존재하는 카테고리 입니다.');
+
+  if (duplicatedCategory) {
+    duplicatedCategory = duplicatedCategory.toJSON();
+    if (
+      duplicatedCategory.id === +expenditureCategoryId &&
+      duplicatedCategory.color.toLowerCase() === color.toLowerCase()
+    ) {
+      throw new Error('이미 존재하는 결제수단입니다.');
+    }
+    if (duplicatedCategory.id !== +expenditureCategoryId) {
+      throw new Error('이미 존재하는 결제수단입니다.');
+    }
   }
 
   await db.expenditureCategory.update(


### PR DESCRIPTION
## 관련 이슈
close #360 [가계부 통계 페이지] 라인차트 월변경 오류 수정
close #363 [가계부 통계 페이지] 파이차트 기타항목 계산 오류 수정
close #364 중복검사 로직 버그 수정

## 구현/수정 내용
- 이전에 만들었던 유틸함수를 사용해 월 변경이 이상하게 되는 오류를 해결하였습니다.
- 파이차트에서 기타(remain) 항목을 계산할 때 하위 항목이 아니라 상위 항목을 계산해버리는 오류가 있어서 해당 부분을 수정하였습니다.
- 프론트에서 중복된 이름인데도 불구하고 색깔이 다른경우 완료버튼이 활성화되는 버그를 해결하였습니다.
- 백엔드에서 중복되는 이름이지만 색깔만 다른경우 수정이 허용되는 오류가 있어서 그 부분의 로직을 수정하였습니다.