### PR TITLE
가계부 설정 페이지 들어갈 때 생기는 오류 해결

### DIFF
--- a/client/src/pages/settings-accountbook-page/SettingsAccountbookPage.tsx
+++ b/client/src/pages/settings-accountbook-page/SettingsAccountbookPage.tsx
@@ -95,6 +95,9 @@ const SettingsAccountbookPage: React.FC = () => {
 
   const onChange = (color: { hex: string }): void => {
     setInputColor(color.hex);
+    if (accountbookStore.accountbook === undefined) {
+      return;
+    }
     if (inputColor.toLowerCase() === (accountbookStore.accountbook as Accountbook).color.toLowerCase()) {
       setColorCheck(false);
     } else {


### PR DESCRIPTION
accountbookStore.accountbook이 undefined라서 생기는 오류 해결했습니다.